### PR TITLE
Fix ZCML conflicts

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.0a2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Remove p.a.contentlisting ZCML registration since collective.solr>=3.1 does this now.
+  [jone]
 
 
 1.0a1 (2012-08-22)

--- a/ftw/solr/configure.zcml
+++ b/ftw/solr/configure.zcml
@@ -19,14 +19,6 @@
     <adapter name="creator_fullname" factory=".indexers.creator_fullname" />
     <adapter name="snippetText" factory=".indexers.snippet_text" />
 
-    <!-- Contentlisting adapters for solr response/flares -->
-    <adapter
-        factory="plone.app.contentlisting.contentlisting.ContentListing"
-        for="collective.solr.parser.SolrResponse" />
-    <adapter
-        factory="ftw.solr.contentlisting.SolrContentListingObject"
-        for="collective.solr.flare.PloneFlare" />
-
     <genericsetup:registerProfile
         name="default"
         title="ftw.solr"
@@ -34,5 +26,5 @@
         description="Installs the ftw.solr package"
         provides="Products.GenericSetup.interfaces.EXTENSION"
         />
-  
+
 </configure>

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(name='ftw.solr',
 
       install_requires=[
         'setuptools',
-        'collective.solr',
+        'collective.solr >= 3.1',
         'collective.monkeypatcher',
         'plone.app.contentlisting',
         'plone.app.search',


### PR DESCRIPTION
Remove p.a.contentlisting ZCML registration since collective.solr>=3.1 does this now.

ftw.solr is not bootable currently:

```
ConfigurationConflictError: Conflicting configuration actions
  For: ('adapter', (<class 'collective.solr.parser.SolrResponse'>,), <InterfaceClass plone.app.contentlisting.interfaces.IContentListing>, '')
    File "/Users/jone/projects/packages/ftw.solr/ftw/solr/configure.zcml", line 23.4-25.52
          <adapter
              factory="plone.app.contentlisting.contentlisting.ContentListing"
              for="collective.solr.parser.SolrResponse" />
    File "/Users/jone/projects/python/cache/eggs/collective.solr-3.1-py2.7.egg/collective/solr/configure.zcml", line 80.2-84.8
        <adapter
            zcml:condition="installed plone.app.contentlisting"
            factory="plone.app.contentlisting.contentlisting.ContentListing"
            for="collective.solr.parser.SolrResponse"
            />
  For: ('adapter', (<class 'collective.solr.flare.PloneFlare'>,), <InterfaceClass plone.app.contentlisting.interfaces.IContentListingObject>, '')
    File "/Users/jone/projects/packages/ftw.solr/ftw/solr/configure.zcml", line 26.4-28.49
          <adapter
              factory="ftw.solr.contentlisting.SolrContentListingObject"
              for="collective.solr.flare.PloneFlare" />
    File "/Users/jone/projects/python/cache/eggs/collective.solr-3.1-py2.7.egg/collective/solr/configure.zcml", line 86.2-90.8
        <adapter
            zcml:condition="installed plone.app.contentlisting"
            factory="collective.solr.contentlisting.FlareContentListingObject"
            for="collective.solr.flare.PloneFlare"
            />
```

/cc @maethu @buchi @lukasgraf 
