### PR TITLE
Update lawgiver configuration

### DIFF
--- a/ftw/solr/lawgiver.zcml
+++ b/ftw/solr/lawgiver.zcml
@@ -7,9 +7,7 @@
 
     <!-- Tell lawgiver that those permissions should not be managed in
          workflows: -->
-    <lawgiver:map_permissions
-        action_group="__unmanaged__"
-        workflow="__unmanaged__"
+    <lawgiver:ignore
         permissions="ftw.solr: Edit search settings"
         />
 


### PR DESCRIPTION
Lawgiver has a new lagiver:ignore directive which we should use.
See https://github.com/4teamwork/ftw.lawgiver/pull/18

/cc @buchi 
