### PR TITLE
Make respecting the navroot for searches configurable.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,10 @@ Changelog
 1.0.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Made respecting the navroot for searches configurable.
+  Only if `ISearchSettings.respect_navroot` is set searches will be constrained
+  to the navigation root (defaults to False).
+  [lgraf]
 
 
 1.0.2 (2013-05-28)

--- a/ftw/solr/browser/search.py
+++ b/ftw/solr/browser/search.py
@@ -34,6 +34,22 @@ class SearchView(browser.Search):
     def render_results(self):
         return self.results_template()
 
+    def filter_query(self, query):
+        registry = getUtility(IRegistry)
+        settings = registry.forInterface(ISearchSettings)
+        original_query = query.copy()
+
+        query = super(SearchView, self).filter_query(query)
+        if settings.respect_navroot:
+            # If respect_navroot is enabled, return the filtered query unchanged
+            return query
+
+        # Otherwise, if there wasn't a path filter in the query before,
+        # remove the path filter that filter_query() put in.
+        if original_query.get('path') is None:
+            query.pop('path')
+        return query
+
     def results(self, query=None, batch=True, b_size=10, b_start=0):
         """Get properly wrapped search results from the catalog.
         'query' should be a dictionary of catalog parameters.

--- a/ftw/solr/interfaces.py
+++ b/ftw/solr/interfaces.py
@@ -8,14 +8,14 @@ class IFtwSolrLayer(Interface):
     """
 
 class ILiveSearchSettings(Interface):
-    
+
     grouping = schema.Bool(
         title=_(u'Enable Grouping in LiveSearch'),
         description=_(u'If enabled, livesearch results are grouped by portal '
                        'type.'),
         default=False,
     )
-    
+
     group_by = schema.List(
         title=_(u'Groups'),
         description=_(u'Specify a list of portal types by which livesearch '
@@ -66,6 +66,11 @@ class ISearchSettings(Interface):
         default=3,
     )
 
+    respect_navroot = schema.Bool(
+        title=_(u'Respect Navigation Root'),
+        description=_(u'Constrain searches to navigation root'),
+        default=False,
+    )
 
 class IZCMLSolrConnectionConfig(Interface):
     """Solr connection settings configured through ZCML.

--- a/ftw/solr/profiles/default/metadata.xml
+++ b/ftw/solr/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-    <version>1002</version>
+    <version>1003</version>
     <dependencies>
         <dependency>profile-collective.solr:default</dependency>
         <dependency>profile-plone.app.search:default</dependency>

--- a/ftw/solr/upgrades/configure.zcml
+++ b/ftw/solr/upgrades/configure.zcml
@@ -29,11 +29,30 @@
       handler="ftw.solr.upgrades.to1002.Upgrades"
       profile="ftw.solr:default"
       />
+
+  <genericsetup:upgradeStep
+      title="Update registry"
+      description=""
+      source="1002"
+      destination="1003"
+      handler="ftw.solr.upgrades.to1003.Upgrades"
+      profile="ftw.solr:default"
+      />
+
   <genericsetup:registerProfile
       name="1002"
       title="ftw.solr.upgrades.1002"
       description=""
       directory="profiles/1002"
+      for="Products.CMFPlone.interfaces.IMigratingPloneSiteRoot"
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      />
+
+  <genericsetup:registerProfile
+      name="1003"
+      title="ftw.solr.upgrades.1003"
+      description=""
+      directory="profiles/1003"
       for="Products.CMFPlone.interfaces.IMigratingPloneSiteRoot"
       provides="Products.GenericSetup.interfaces.EXTENSION"
       />

--- a/ftw/solr/upgrades/profiles/1003/registry.xml
+++ b/ftw/solr/upgrades/profiles/1003/registry.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<registry>
+    <records interface="ftw.solr.interfaces.ISearchSettings" />
+</registry>

--- a/ftw/solr/upgrades/to1003.py
+++ b/ftw/solr/upgrades/to1003.py
@@ -1,0 +1,8 @@
+from ftw.upgrade import UpgradeStep
+
+
+class Upgrades(UpgradeStep):
+
+    def __call__(self):
+        self.setup_install_profile(
+            'profile-ftw.solr.upgrades:1003')


### PR DESCRIPTION
By default, `plone.app.search` always constrains searches to the navigation root by adding a `path` filter to the query in `SearchView.filter_query()`.

This change overrides `filter_query()` in order to make this behaviour configurable. Only if `ISearchSettings.respect_navroot` is set (defaults to False), searches will be constrained to the navigation root.

Note: This requires the ftw.solr profile to be upgraded to 1003.
@buchi: Since I released ftw.solr since we discussed this, I decided to create a 1003 upgrade profile + upgrade step anyway.

/cc @maethu @jone
