### PR TITLE
Sort facet fields in the order specified in the Solr control panel.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.1.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Sort facet fields in the order specified in the Solr control panel.
+  [buchi]
 
 
 1.1.1 (2013-06-01)

--- a/ftw/solr/browser/facets.py
+++ b/ftw/solr/browser/facets.py
@@ -8,6 +8,8 @@ from zope.i18nmessageid import Message
 from collective.solr.browser import facets
 from collective.solr.browser.facets import param, facetParameters
 from collective.solr.interfaces import IFacetTitleVocabularyFactory
+from collective.solr.interfaces import ISolrConnectionConfig
+
 
 FACET_QUERY_POSITIONS = {
     '[NOW/DAY TO *]': 0,
@@ -85,6 +87,16 @@ class SearchFacetsView(facets.SearchFacetsView):
                 ))
             info.append(dict(title=facet_title, counts=sorted(counts,
                 key=lambda x: FACET_QUERY_POSITIONS.get(x['name'], 100))))
+
+        # Sort facets in the order stored in the configuration
+        config = queryUtility(ISolrConnectionConfig)
+        if config is not None:
+            def pos(item):
+                try:
+                    return config.facets.index(item['title'])
+                except ValueError:
+                    return len(config.facets)
+            info.sort(key=pos)
 
         return info
 

--- a/ftw/solr/tests/data/facets_response.xml
+++ b/ftw/solr/tests/data/facets_response.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<response>
+  <lst name="responseHeader">
+    <int name="status">0</int>
+    <int name="QTime">1</int>
+    <lst name="params">
+      <str name="facet.limit">-1</str>
+      <str name="rows">0</str>
+      <str name="facet">true</str>
+      <arr name="facet.field">
+        <str>type</str>
+        <str>section</str>
+        <str>topics</str>
+      </arr>
+      <str name="indent">10</str>
+      <str name="q">solr</str>
+    </lst>
+  </lst>
+  <result name="response" numFound="400" start="0"/>
+  <lst name="facet_counts">
+    <lst name="facet_queries">
+      <int name="modified:[NOW/DAY TO *]">0</int>
+      <int name="modified:[NOW/DAY-1DAY TO NOW/DAY]">0</int>
+      <int name="modified:[NOW/DAY-7DAYS TO *]">0</int>
+      <int name="modified:[NOW/DAY-1MONTH TO *]">5</int>
+      <int name="modified:[NOW/DAY-1YEAR TO *]">30</int>
+      <int name="modified:[* TO NOW/DAY-1YEAR]">400</int>
+    </lst>
+    <lst name="facet_fields">
+      <lst name="type">
+        <int name="hardware">30</int>
+        <int name="monitor">20</int>
+        <int name="electronics">1</int>
+        <int name="software">1</int>
+      </lst>
+      <lst name="section">
+        <int name="international">10</int>
+      </lst>
+      <lst name="topics">
+        <int name="spam">100</int>
+        <int name="eggs">5</int>
+      </lst>
+    </lst>
+  </lst>
+</response>

--- a/ftw/solr/tests/test_facets.py
+++ b/ftw/solr/tests/test_facets.py
@@ -1,0 +1,33 @@
+from collective.solr.interfaces import ISolrConnectionConfig
+from collective.solr.parser import SolrResponse
+from ftw.solr.browser.facets import SearchFacetsView
+from ftw.solr.testing import SOLR_FUNCTIONAL_TESTING
+from ftw.solr.tests.utils import getData
+from unittest2 import TestCase
+from zope.component import queryUtility
+
+
+class TestFacetsView(TestCase):
+
+    layer = SOLR_FUNCTIONAL_TESTING
+
+    def test_facets_order(self):
+        portal = self.layer['portal']
+        request = self.layer['request']
+        request.form.update({'facet_field': ['type', 'section', 'topics']})
+        response = SolrResponse(getData('facets_response.xml'))
+        view = SearchFacetsView(portal, request)
+        view.kw = dict(results=response)
+
+        config = queryUtility(ISolrConnectionConfig)
+        config.facets = ['type', 'section', 'topics']
+        facets = view.facets()
+        self.assertEquals(['type', 'section', 'topics'],
+            [facets[0]['title'], facets[1]['title'], facets[2]['title']],
+            msg='Wrong facet order.')
+
+        config.facets = ['section', 'topics', 'type']
+        facets = view.facets()
+        self.assertEquals(['section', 'topics', 'type'],
+            [facets[0]['title'], facets[1]['title'], facets[2]['title']],
+            msg='Wrong facet order.')


### PR DESCRIPTION
Fixes #19 
