### PR TITLE
Handle invalid facet parameters.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -11,6 +11,9 @@ Changelog
   is set to False.
   [buchi]
 
+- Handle invalid facet parameters.
+  [buchi]
+
 
 1.1.1 (2013-06-01)
 ------------------

--- a/ftw/solr/patches/configure.zcml
+++ b/ftw/solr/patches/configure.zcml
@@ -13,6 +13,13 @@
         />
 
     <monkey:patch
+        description="Remove invalid facet field parameters"
+        module="collective.solr.dispatcher"
+        original="cleanupQueryParameters"
+        replacement=".mangler.cleanupQueryParameters"
+        />
+
+    <monkey:patch
         description="Allow more solr query parameters"
         module="collective.solr.dispatcher"
         original="extractQueryParameters"

--- a/ftw/solr/tests/test_mangler.py
+++ b/ftw/solr/tests/test_mangler.py
@@ -1,0 +1,39 @@
+from unittest import TestCase
+from ftw.solr.patches.mangler import cleanupQueryParameters
+from collective.solr.parser import SolrSchema, SolrField
+
+
+class TestQueryParameters(TestCase):
+
+    def test_keep_valid_facet_fields(self):
+        schema = SolrSchema()
+        schema['foo'] = SolrField(indexed=True)
+        schema['bar'] = SolrField(indexed=True)
+        params = cleanupQueryParameters({'facet.field': 'foo'}, schema)
+        self.assertEquals({'facet': 'true', 'facet.field': ['foo']}, params)
+        params = cleanupQueryParameters({'facet.field': ['foo', 'bar']},
+                                        schema)
+        self.assertEquals({'facet': 'true', 'facet.field': ['foo', 'bar']},
+                          params)
+
+    def test_remove_invalid_facet_fields(self):
+        schema = SolrSchema()
+        params = cleanupQueryParameters({'facet.field': 'foo'}, schema)
+        self.assertEquals({}, params)
+        params = cleanupQueryParameters({'facet.field': ['foo', 'bar']},
+                                        schema)
+        self.assertEquals({}, params)
+
+        schema['foo'] = SolrField(indexed=False)
+        params = cleanupQueryParameters({'facet.field': 'foo'}, schema)
+        self.assertEquals({}, params)
+        params = cleanupQueryParameters({'facet.field': ['foo', 'bar']},
+                                        schema)
+        self.assertEquals({}, params)
+
+    def test_remove_invalid_and_keep_valid_facet_fields(self):
+        schema = SolrSchema()
+        schema['bar'] = SolrField(indexed=True)
+        params = cleanupQueryParameters({'facet.field': ['foo', 'bar']},
+                                        schema)
+        self.assertEquals({'facet': 'true', 'facet.field': ['bar']}, params)


### PR DESCRIPTION
Removes invalid facet parameters from the query which would cause a Solr Exception.

We need this because googlebot is trying to reindex old search results having a no longer existing facet.field in the query and thus is cluttering our logs. 
