### PR TITLE
Always insert the default 'select' search handler into the query paramet...

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -27,6 +27,12 @@ Changelog
 - Escape forward slashes in all query values, not only in paths.
   [buchi]
 
+- Always insert the default 'select' search handler into the query parameters if
+  no 'qt' parameter is provided. We need this because we have to disable the
+  /select search handler in the Solr configuration to be able to select other search
+  handlers by parameter.
+  [buchi]
+
 
 1.1.1 (2013-06-01)
 ------------------

--- a/ftw/solr/patches/mangler.py
+++ b/ftw/solr/patches/mangler.py
@@ -46,6 +46,16 @@ def extractQueryParameters(args):
         elif key == 'b_size':
             params['rows'] = int(value)
             del args[key]
+
+    # Add default search handler if no search handler is specified in the 
+    # query. With Solr 4 we have to disable the /select search handler to be
+    # able to select another search handler with the 'qt' parameter. However
+    # queries without a 'qt' parameter do no longer work.
+    # TODO: In the future we should extend c.solr to handle multiple search
+    # handlers by URL.
+    if 'qt' not in params:
+        params['qt'] = 'select'
+
     return params
 
 # Remove facet.field parameters specifying an non-existing field.

--- a/ftw/solr/tests/test_mangler.py
+++ b/ftw/solr/tests/test_mangler.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 from ftw.solr.patches.mangler import cleanupQueryParameters
+from ftw.solr.patches.mangler import extractQueryParameters
 from collective.solr.parser import SolrSchema, SolrField
 
 
@@ -37,3 +38,10 @@ class TestQueryParameters(TestCase):
         params = cleanupQueryParameters({'facet.field': ['foo', 'bar']},
                                         schema)
         self.assertEquals({'facet': 'true', 'facet.field': ['bar']}, params)
+
+    def test_insert_default_qt_parameter(self):
+        self.assertEquals({'qt': 'select'}, extractQueryParameters({}))
+
+    def test_keep_existing_qt_parameter(self):
+        self.assertEquals({'qt': 'search'}, extractQueryParameters(
+            {'qt': 'search'}))


### PR DESCRIPTION
...ers if

no 'qt' parameter is provided.
