### PR TITLE
Es adjust searchbox

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,11 @@ Changelog
 1.1.3 (unreleased)
 ------------------
 
+- Fix bug after searching in current folder.
+  The searchview is called on the siteroot. If you want to search
+  in the same folder again, it will search the whole site.
+  Searchview is now called on the context itslef.
+
 - The searchbox_currentfolder_only checkbox remembers the state after
   a searchrequest.
 

--- a/ftw/solr/browser/searchbox.pt
+++ b/ftw/solr/browser/searchbox.pt
@@ -2,7 +2,7 @@
      i18n:domain="plone">
     <form name="searchform"
           action="@@search"
-          tal:attributes="action string:${view/site_url}/@@search">
+          tal:attributes="action python:hasattr(context, 'absolute_url') and '%s/@@search' % context.absolute_url() or '%s/@@search' % view.site_url()">
 
         <label for="searchGadget" class="hiddenStructure"
                     i18n:translate="text_search">Search Site</label>


### PR DESCRIPTION
@lukasgraf @buchi I changed the behavior of the searchbox viewlet:
- Fix bug after searching in current folder.
  The searchview is called on the siteroot. If you want to search
  in the same folder again, it will search the whole site.
  Searchview is now called on the context itslef.
- The searchbox_currentfolder_only checkbox remembers the state after
  a searchrequest.
