### PR TITLE
Allow dots in simple terms / simple searches.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,10 @@ Changelog
 1.4.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Allow dots in simple terms / simple searches.
+  Fixes issue where a dot in a search term causes the search_pattern template to
+  be circumvented, and therefore messing up the relevancy ranking.
+  [lgraf]
 
 
 1.4.0 (2015-02-26)

--- a/ftw/solr/patches/utils.py
+++ b/ftw/solr/patches/utils.py
@@ -1,10 +1,10 @@
 # Modified implementation from c.solr.utils:
-# Treat search terms ending with a digit as simple
+# - simple terms may contain digits
+# - simple terms may contain dots
 
 from re import compile, UNICODE
 
-
-simpleTerm = compile(r'^[\w\d]+$', UNICODE)
+simpleTerm = compile(r'^[\w\d\.]+$', UNICODE)
 def isSimpleTerm(term):
     if isinstance(term, str):
         term = unicode(term, 'utf-8', 'ignore')
@@ -12,7 +12,7 @@ def isSimpleTerm(term):
 
 
 operators = compile(r'(.*)\s+(AND|OR|NOT)\s+', UNICODE)
-simpleCharacters = compile(r'^[\w\d\?\*\s]+$', UNICODE)
+simpleCharacters = compile(r'^[\w\d\?\*\s\.]+$', UNICODE)
 def isSimpleSearch(term):
     term = term.strip()
     if isinstance(term, str):

--- a/ftw/solr/tests/test_utils.py
+++ b/ftw/solr/tests/test_utils.py
@@ -1,4 +1,5 @@
 from ftw.solr.patches.utils import isSimpleSearch
+from ftw.solr.patches.utils import isSimpleTerm
 from unittest import TestCase
 
 
@@ -10,3 +11,17 @@ class TestIsSimpleSearch(TestCase):
         self.assertFalse(isSimpleSearch('"bar"'))
         self.assertFalse(isSimpleSearch('foo "bar"'))
         self.assertFalse(isSimpleSearch('foo"bar'))
+
+    def test_simple_searches_may_contain_dots(self):
+        self.assertTrue(isSimpleSearch('foo.bar'))
+        self.assertTrue(isSimpleSearch('foo.bar baz'))
+
+
+class TestIsSimpleTerm(TestCase):
+
+    def test_simple_terms_may_contain_dots(self):
+        self.assertTrue(isSimpleTerm('foo.bar'))
+
+    def test_simple_terms_may_contain_digits(self):
+        self.assertTrue(isSimpleTerm('foo7bar'))
+        self.assertTrue(isSimpleTerm('foo7'))


### PR DESCRIPTION
Fixes issue where a dot in a search term causes the `search_pattern` template to be circumvented, and therefore messing up the relevancy ranking because none of the weighting of `Title` or `Description` is applied, no wildcards are added, etc.

@buchi