### PR TITLE
Implement accessibility support for solr facets.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 2.0.0 (unreleased)
 ------------------
 
+- Implement accessibility support for solr facets.
+  [Kevin Bieri]
+
 - Make `only in current folder section` selectable in the dropdown menu.
   [Kevin Bieri]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,12 @@ Changelog
 2.0.0 (unreleased)
 ------------------
 
+- Fix css selector of selected facest.
+  [mathias.leimgruber]
+
+- Implement accessible remove facet link.
+  [mathias.leimgruber]
+
 - Implement accessibility support for solr facets.
   [Kevin Bieri]
 

--- a/ftw/solr/browser/available-facets.pt
+++ b/ftw/solr/browser/available-facets.pt
@@ -4,15 +4,26 @@
      i18n:domain="solr">
 
   <tal:facets repeat="facet facets">
-    <div class="filter facets" tal:define="facet_counts facet/counts">
-      <span tal:content="facet/title" i18n:translate="" tal:attributes="class python: not facet_counts and 'selected' or ''" />
-      <ul tal:condition="facet_counts">
-          <li tal:repeat="item facet_counts">
-              <a href="#" tal:content="string:${item/title} (${item/count})"
-                 tal:attributes="href string:${request/ACTUAL_URL}?${item/query}" />
-          </li>
-      </ul>
-    </div>
+    <tal:facet tal:define="facet_counts facet/counts">
+      <div tal:attributes="class python: not facet_counts and 'selected filter' or 'filter'">
+        <a href="#"
+           tal:content="facet/title"
+           i18n:translate=""
+           tal:attributes="tabindex python: '-1' if not facet_counts else nothing;
+                           aria-controls string: ${repeat/facet/index}_filter;
+                           aira-owns string: ${repeat/facet/index}_filter"
+           aria-haspopup="true"></a>
+        <ul class="facets"
+            tal:condition="facet_counts"
+            aria-hidden="true"
+            tal:attributes="id string: ${repeat/facet/index}_filter">
+            <li tal:repeat="item facet_counts">
+                <a href="#" class="facet" tal:content="string:${item/title} (${item/count})"
+                   tal:attributes="href string:${request/ACTUAL_URL}?${item/query}" />
+            </li>
+        </ul>
+      </div>
+    </tal:facet>
   </tal:facets>
 
 </div>

--- a/ftw/solr/browser/resources/facets.js
+++ b/ftw/solr/browser/resources/facets.js
@@ -1,0 +1,141 @@
+/*
+Go trough the filter by hitting tab. This will focus the filter.
+
+Controls on the filter:
+- right arrow: open the focused filter
+- down arrow: open the focused filter
+- enter: open the focused filter
+
+Controls on open filter:
+- escape: close the open filter
+- left arrow: close the open filter
+- down arrow: focus next facet
+- up arrow: focus previous facet
+ */
+
+(function(global) {
+  'use strict';
+
+  var facets = {
+    filter: null,
+    currentFacet: null,
+    facets: [],
+    next: function() {
+      if(this.currentFacet === this.facets.length - 1) {
+        this.currentFacet = 0;
+      } else {
+        this.currentFacet++;
+      }
+      this.focus();
+    },
+    prev: function() {
+      if(this.currentFacet === 0) {
+        this.currentFacet = this.facets.length - 1;
+      } else {
+        this.currentFacet--;
+      }
+      this.focus();
+    },
+    init: function(filter) {
+      this.filter = filter;
+      this.currentFacet = 0;
+      this.facets = filter.find(".facet");
+      this.focus();
+    },
+    focus: function() {
+      focus(this.facets.eq(this.currentFacet));
+    }
+  }
+
+  var currentFilter = $();
+
+  function focus(target) {
+    blur();
+    $(".active").removeClass("active");
+    target.addClass("active accessibility-tab-focus").focus();
+  }
+
+  function blur() {
+    $(".accessibility-tab-focus").removeClass("accessibility-tab-focus");
+  }
+
+  function openFilter(filter) {
+    currentFilter = filter;
+    $(".filter").not(filter).find(".facets").hide();
+    filter.find(".facets").show().attr("aria-hidden", false);
+  }
+
+  function toggleFilter(filter) {
+    $(".filter").not(filter).find(".facets").hide();
+    var facets = filter.find(".facets");
+    facets.toggle().attr("aria-hidden", facets.attr("aria-hidden") !== "true");
+  }
+
+  function closeFilter() {
+    focus(currentFilter.find(">a"));
+    $(".facets").hide().attr("aria-hidden", true);
+  }
+
+  $(document).on("click", function(event) {
+    var target = $(event.target);
+    if(!(target.hasClass("filter") || target.parent().hasClass("filter"))) {
+      closeFilter();
+      blur();
+    }
+  });
+
+  $(document).on("click", ".filter", function(event) {
+    var filter = $(event.currentTarget);
+    var target = $(event.target);
+
+    if(target.parent().hasClass("filter")) {
+      event.preventDefault();
+      toggleFilter(filter);
+    }
+  });
+
+  $(document).on("keydown", ".filter", function(event) {
+    var filter = $(event.currentTarget);
+    var target = $(event.target);
+    if(!target.parents().hasClass("filter")) {
+      return;
+    }
+    switch (event.which) {
+      case $.ui.keyCode.DOWN:
+        event.preventDefault();
+        if(target.hasClass("facet")) {
+          facets.next();
+        } else {
+          openFilter(filter);
+          facets.init(filter);
+        }
+        break
+      case $.ui.keyCode.UP:
+        event.preventDefault();
+        facets.prev();
+        break
+      case $.ui.keyCode.RIGHT:
+        event.preventDefault();
+        openFilter(filter);
+        facets.init(filter);
+        break
+      case $.ui.keyCode.LEFT:
+        event.preventDefault();
+        closeFilter();
+        break
+      case $.ui.keyCode.ESCAPE:
+        event.preventDefault();
+        closeFilter();
+        blur();
+        break
+      case $.ui.keyCode.ENTER:
+        if(target.hasClass("filter")) {
+          event.preventDefault();
+          openFilter(filter);
+          facets.init(filter);
+        }
+        break
+    }
+  });
+
+}(window));

--- a/ftw/solr/browser/resources/ftwtheming.scss
+++ b/ftw/solr/browser/resources/ftwtheming.scss
@@ -107,104 +107,92 @@ $dropdown-link-color-hover: $link-hover-color !default;
 }
 
 #filter-form {
+
+  @include clearfix();
+  padding-bottom: .5em;
+  margin-bottom: 1em;
+  padding-top: 13px;
+  border-bottom: 1px solid lighten($primary-color, 50%);
+
   .searchButton {
     display: none;
   }
 
-  .search-facets {
+  .searchBox {
+    margin-bottom: 10px;
+    margin-right: 1em;
     display: inline-block;
-    vertical-align: top;
-    padding-top: 10px;
   }
 
-  > div {
-    clear: both;
-    padding-bottom: .5em;
-    margin-bottom: 1em;
-    padding-top: 13px;
-    border-bottom: 1px solid lighten($primary-color, 50%);
+  .facets {
+    @include ul(plain);
+    display: none;
+    z-index: 1;
+    position: absolute;
+    white-space: nowrap;
+    padding: 8px 0;
+    border: 1px solid $dropdown-border-color;
+    background-color: $dropdown-bg-color;
+    border-radius: $border-radius-primary;
+    @include boxshadow(0.5em 1em 2em -1em $dropdown-border-color);
+    margin-left: -16px;
+    margin-top: 10px;
 
-    &.no-border {
-      border-bottom: none;
-      border-top: none;
-      margin-bottom: 0;
-    }
+    > li > a {
+      padding: .3em 1.5em;
+      color: $color-text;
+      display: block;
 
-    &:first-child {
-      .filter {
-        margin-bottom: 10px;
+      &:hover, &.active {
+        text-decoration: none;
+        background-color: $gray-lighter;
       }
     }
-    @include screen-medium {
-      .filter {
-        display: inline-block;
-      }
+  }
+
+  .filter {
+    @include screen-medium() {
+      display: inline-block;
     }
-    .filter {
-      margin-right: 1em;
+    display: block;
+    margin-bottom: 10px;
+    margin-right: 1em;
+    position: relative;
 
-      input.searchPage {
-        line-height: normal;
+    > a {
+      @extend .fa-icon-right;
+      font-weight: bold;
+      color: $link-color;
+      padding-left: 10px;
+
+      &:after {
+        @extend .fa-chevron-down:before;
       }
 
-      > a {
-        color: $link-color;
-        padding-left: 10px;
-        font-weight: bold;
-
-        @extend .fa-icon-right;
-
-        &:after {
-          @extend .fa-chevron-down:before;
-        }
-
+      &:hover {
+        text-decoration: none;
       }
 
-      &.selected a {
+      &.selected {
         color: $text-color;
         font-weight: normal;
         cursor: default;
         &:after {
           content: none;
         }
-        &:hover {
-          text-decoration: none;
-        }
-      }
-
-      ul {
-        @include ul("plain");
-
-        display: none;
-        position: absolute;
-        padding: 8px 0;
-        border: 1px solid $dropdown-border-color;
-        background-color: $dropdown-bg-color;
-        border-radius: $border-radius-primary;
-
-        @include boxshadow(0.5em 1em 2em -1em $dropdown-border-color);
-
-        margin-left: -16px;
-        margin-top: 10px;
-
-        li {
-          margin: 0;
-          min-width: 10em;
-
-          a {
-            cursor: pointer;
-            padding: 0.3em 1.5em;
-            color: $dropdown-link-color;
-            display: block;
-
-            &:focus {
-              background-color: $gray-lighter;
-            }
-          }
-        }
       }
     }
   }
+
+  .search-facets {
+    @include screen-medium() {
+      display: inline-block;
+      padding-top: 0;
+    }
+    padding-top: 10px;
+  }
+
+
 }
 
 .ui-autocomplete {

--- a/ftw/solr/browser/resources/ftwtheming.scss
+++ b/ftw/solr/browser/resources/ftwtheming.scss
@@ -172,16 +172,17 @@ $dropdown-link-color-hover: $link-hover-color !default;
       &:hover {
         text-decoration: none;
       }
+    }
 
-      &.selected {
-        color: $text-color;
-        font-weight: normal;
-        cursor: default;
-        &:after {
-          content: none;
-        }
+    &.selected a{
+      color: $text-color;
+      font-weight: normal;
+      cursor: default;
+      &:after {
+        content: none;
       }
     }
+
   }
 
   .search-facets {

--- a/ftw/solr/browser/resources/ftwtheming.scss
+++ b/ftw/solr/browser/resources/ftwtheming.scss
@@ -142,15 +142,13 @@ $dropdown-link-color-hover: $link-hover-color !default;
     }
     .filter {
       margin-right: 1em;
-      overflow: auto;
 
       input.searchPage {
         line-height: normal;
       }
 
-      span {
+      > a {
         color: $link-color;
-        cursor: pointer;
         padding-left: 10px;
         font-weight: bold;
 
@@ -160,10 +158,17 @@ $dropdown-link-color-hover: $link-hover-color !default;
           @extend .fa-chevron-down:before;
         }
 
-        &.selected {
-          color: $text-color;
-          font-weight: normal;
-          cursor: default;
+      }
+
+      &.selected a {
+        color: $text-color;
+        font-weight: normal;
+        cursor: default;
+        &:after {
+          content: none;
+        }
+        &:hover {
+          text-decoration: none;
         }
       }
 
@@ -172,7 +177,6 @@ $dropdown-link-color-hover: $link-hover-color !default;
 
         display: none;
         position: absolute;
-        overflow: auto;
         padding: 8px 0;
         border: 1px solid $dropdown-border-color;
         background-color: $dropdown-bg-color;
@@ -193,10 +197,8 @@ $dropdown-link-color-hover: $link-hover-color !default;
             color: $dropdown-link-color;
             display: block;
 
-            &:hover {
-              background-color: $dropdown-bg-color-hover;
-              color: $dropdown-link-color-hover;
-              text-decoration: none;
+            &:focus {
+              background-color: $gray-lighter;
             }
           }
         }

--- a/ftw/solr/browser/resources/solr.css
+++ b/ftw/solr/browser/resources/solr.css
@@ -148,7 +148,6 @@
 
 #filter-form > div .filter {
   margin-right: 1em;
-  overflow: auto;
 }
 
 #filter-form > div .filter input.searchPage {
@@ -172,7 +171,6 @@
   margin: 0;
   display: none;
   position: absolute;
-  overflow: auto;
   padding: 8px 0;
   background-color: #fff;
   border: 1px solid #cccccc;

--- a/ftw/solr/browser/results.pt
+++ b/ftw/solr/browser/results.pt
@@ -13,7 +13,7 @@
 
         <div id="filter-form" i18n:domain="ftw.solr">
           <div>
-            <div class="searchBox LSBox filter"
+            <div class="searchBox LSBox"
                  tal:define="portal context/@@plone_portal_state/portal;
                              first_call not:request/advanced_search|nothing;
                              DateTime python:modules['DateTime'].DateTime;">

--- a/ftw/solr/browser/search.js
+++ b/ftw/solr/browser/search.js
@@ -43,24 +43,9 @@ jQuery(function ($) {
     });
 
     // Handle clicks in batch navigation and facets
-    $('#portal-searchfacets a, #search-results .listingBar a, .filter.facets a').live('click', function (e) {
+    $('#portal-searchfacets a, #search-results .listingBar a, .filter .facets a').live('click', function (e) {
         History.pushState(null, $("title").text(), $(this).attr('href'));
         e.preventDefault();
     });
 
-});
-
-// solr search facets drop downs
-$(function(){
-  $('body').click(function(e){
-    if (!$(e.target).is('#filter-form .filter:not(.LSBox) > span')){
-        $('#filter-form .filter:not(.LSBox) ul').hide();
-    }
-  });
-
-  $('.solrSearchPage').on('click', '#filter-form .filter:not(.LSBox) > span', function(e){
-    var $this = $(this);
-    $this.parent().siblings(':not(.LSBox)').find('> span').next().hide();
-    $this.next().toggle();
-  });
 });

--- a/ftw/solr/browser/selected-facets.pt
+++ b/ftw/solr/browser/selected-facets.pt
@@ -15,8 +15,7 @@
                   tal:content="item/value" />
             <a class="facetRemoveItem"
                tal:attributes="href string:${request/ACTUAL_URL}?${item/query}"
-               alt="Remove this search limit..." i18n:attributes="alt"
-               i18n:translate=""></a>
+               i18n:translate="">Remove this search limit...</a>
         </li>
     </ul>
 

--- a/ftw/solr/profiles/default/jsregistry.xml
+++ b/ftw/solr/profiles/default/jsregistry.xml
@@ -10,4 +10,7 @@
     <javascript id="++resource++ftw.solr/livesearch.js"
         insert-after="livesearch.js" compression="none" authenticated="False" />
 
+    <javascript id="++resource++ftw.solr/facets.js"
+        insert-after="++resource++ftw.solr/livesearch.js" compression="none" authenticated="False" />
+
 </object>

--- a/ftw/solr/upgrades/20160217163924_register_javascript_for_accessiblity_handling_of_the_facets/jsregistry.xml
+++ b/ftw/solr/upgrades/20160217163924_register_javascript_for_accessiblity_handling_of_the_facets/jsregistry.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<object name="portal_javascripts" meta_type="JavaScripts Registry">
+
+    <javascript id="++resource++ftw.solr/facets.js"
+        insert-after="++resource++ftw.solr/livesearch.js" compression="none" authenticated="False" />
+
+</object>

--- a/ftw/solr/upgrades/20160217163924_register_javascript_for_accessiblity_handling_of_the_facets/upgrade.py
+++ b/ftw/solr/upgrades/20160217163924_register_javascript_for_accessiblity_handling_of_the_facets/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class RegisterJavascriptForAccessiblityHandlingOfTheFacets(UpgradeStep):
+    """Register javascript for accessiblity handling of the facets.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
According to access4all the facets of the solr search has to be
reachable with the keyboard.

Go trough the filter by hitting tab. This will focus the filter.

Controls on the filter:
- right arrow: open the focused filter
- down arrow: open the focused filter
- enter: open the focused filter

Controls on open filter:
- escape: close the open filter 
- left arrow: close the open filter
- down arrow: focus next facet
- up arrow: focus previous facet

![facets_accessiblity](https://cloud.githubusercontent.com/assets/1637820/13139223/d79a79c6-d62b-11e5-84f5-972329da6a96.gif)