### PR TITLE
Respect the facets configured in the Solr control panel.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 2.0.0 (unreleased)
 ------------------
 
+- Respect the facets configured in the Solr control panel.
+  [mbaechtold]
+
 - Fix css selector of selected facest.
   [mathias.leimgruber]
 

--- a/ftw/solr/browser/configure.zcml
+++ b/ftw/solr/browser/configure.zcml
@@ -16,7 +16,7 @@
         for="OFS.interfaces.IFolder"
         name="available-facets"
         template="available-facets.pt"
-        class=".facets.AvailableSearchFacetsView"
+        class="ftw.solr.browser.facets.SearchFacetsView"
         permission="zope2.View"
         allowed_attributes="facet_parameters" />
 

--- a/ftw/solr/browser/facets.py
+++ b/ftw/solr/browser/facets.py
@@ -158,26 +158,3 @@ class SearchFacetsView(facets.SearchFacetsView):
         facets, dependencies = facetParameters(self)
         return urlencode({'facet': 'true', 'facet.field': facets, },
                          doseq=True)
-
-
-class AvailableSearchFacetsView(SearchFacetsView):
-
-    def facets(self):
-        possible_facets = super(AvailableSearchFacetsView, self).facets()
-        if possible_facets is None:
-            return []
-
-        facets = [{'title': 'portal_type',
-                   'counts': []},
-                  {'title': 'site_section',
-                   'counts': []},
-                  {'title': 'modified',
-                   'counts': []}]
-
-        return [self.update_facet(facet, possible_facets) for facet in facets]
-
-    def update_facet(self, facet, possible_facets):
-        for possible_facet in possible_facets:
-            if facet['title'] == possible_facet['title']:
-                facet.update(possible_facet)
-        return facet


### PR DESCRIPTION
The current implementation does not respect the facets configured in the Solr control panel. Some default facets are rendered instead (portal_type,  site_section, modified).

This commit removes the hard coded facets so that the configured facets are rendered.

I also noticed that the facet "modified" is rendered even if it is not configured. This will be handled in an upcoming issue.

/cc @elioschmutz, @maethu 