### PR TITLE
Fix readme.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,14 +4,12 @@ Changelog
 1.5.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Respect the facets configured in the Solr control panel.
+  [mbaechtold]
 
 
 1.5.0 (2016-03-31)
 ------------------
-
-- Respect the facets configured in the Solr control panel.
-  [mbaechtold]
 
 - Fix css selector of selected facest.
   [mathias.leimgruber]


### PR DESCRIPTION
The release notes of 1.5.0 got messed up during the release process: the changes introduced in the commit 3507cce4fd7ff1 (via https://github.com/4teamwork/ftw.solr/pull/60) did not go into this release, they are still only available on the master branch:

<img width="1060" alt="screenshot" src="https://cloud.githubusercontent.com/assets/28220/14881767/b082a782-0d35-11e6-9c6b-e7e38860df0d.png">
