### PR TITLE
Disable marking special links on dropdown links in searchpage.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.5.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Disable special links on facets dropdown.
+  [Kevin Bieri]
 
 
 1.5.1 (2016-04-29)

--- a/ftw/solr/browser/available-facets.pt
+++ b/ftw/solr/browser/available-facets.pt
@@ -7,6 +7,7 @@
     <tal:facet tal:define="facet_counts facet/counts">
       <div tal:attributes="class python: not facet_counts and 'selected filter' or 'filter'">
         <a href="#"
+           class="link-plain"
            tal:content="facet/title"
            i18n:translate=""
            tal:attributes="tabindex python: '-1' if not facet_counts else nothing;


### PR DESCRIPTION
Fixes https://github.com/4teamwork/ftw.solr/issues/59

Plone wraps `https` links with a span tag by default. This behavior
breaks the dropdown functionality on the solr searchpage.
As documented in https://github.com/plone/Products.CMFPlone/blob/4.3.7/Products/CMFPlone/skins/plone_ecmascript/mark_special_links.js#L5
add the `link-plain` class to prevent this behavior.