### PR TITLE
Dexterity behaviors for search fields

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,8 @@ Changelog
 1.5.4 (unreleased)
 ------------------
 
+- Add IShowInSearch behavior. [jone]
+
 - Fix html structure of search in current folder. input in a tag is not allowed.
   [mathias.leimgruber]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 1.5.4 (unreleased)
 ------------------
 
-- Add IShowInSearch behavior. [jone]
+- Add IShowInSearch and ISearchwords behaviors. [jone]
 
 - Fix html structure of search in current folder. input in a tag is not allowed.
   [mathias.leimgruber]

--- a/ftw/solr/behaviors.py
+++ b/ftw/solr/behaviors.py
@@ -1,6 +1,7 @@
 from ftw.solr import _
 from plone.autoform import directives
 from plone.autoform.interfaces import IFormFieldProvider
+from plone.indexer import indexer
 from plone.supermodel import model
 from plone.supermodel.model import Schema
 from z3c.form.interfaces import IAddForm
@@ -8,6 +9,7 @@ from z3c.form.interfaces import IEditForm
 from zope.i18nmessageid import MessageFactory
 from zope.interface import alsoProvides
 from zope.schema import Bool
+from zope.schema import Text
 
 
 _plone = MessageFactory('plone')
@@ -34,3 +36,36 @@ class IShowInSearch(Schema):
 
 
 alsoProvides(IShowInSearch, IFormFieldProvider)
+
+
+class ISearchwords(Schema):
+    """Adds a "Searchwords" field for adding additional search words
+    the the search index for improving search results.
+    """
+
+    model.fieldset(
+        'settings',
+        label=_plone(u'Settings'),
+        fields=['searchwords'])
+
+    directives.write_permission(searchwords='ftw.solr.EditSearchSettings')
+    directives.omitted('searchwords')
+    directives.no_omit(IEditForm, 'searchwords')
+    directives.no_omit(IAddForm, 'searchwords')
+    searchwords = Text(
+        title=_(u'label_searchwords', default=u'Search words'),
+        description=_(u'help_searchwords',
+                      default=u'Specify words for which this item will show up '
+                      u'as the first search result. Multiple words can be '
+                      u'specified on new lines.'))
+
+alsoProvides(ISearchwords, IFormFieldProvider)
+
+
+@indexer(ISearchwords)
+def searchwords_indexer(obj):
+    words = getattr(ISearchwords(obj), 'searchwords', '')
+    if not isinstance(words, unicode):
+        words = words.decode('utf-8')
+
+    return filter(None, [word.strip('\r ') for word in words.split('\n')])

--- a/ftw/solr/behaviors.py
+++ b/ftw/solr/behaviors.py
@@ -1,0 +1,36 @@
+from ftw.solr import _
+from plone.autoform import directives
+from plone.autoform.interfaces import IFormFieldProvider
+from plone.supermodel import model
+from plone.supermodel.model import Schema
+from z3c.form.interfaces import IAddForm
+from z3c.form.interfaces import IEditForm
+from zope.i18nmessageid import MessageFactory
+from zope.interface import alsoProvides
+from zope.schema import Bool
+
+
+_plone = MessageFactory('plone')
+
+
+class IShowInSearch(Schema):
+    """Behavior adding a "Show in search" checkbox in order to make
+    it possible to exclude certain content from the search results.
+    """
+
+    model.fieldset(
+        'settings',
+        label=_plone(u'Settings'),
+        fields=['showinsearch'])
+
+    directives.write_permission(showinsearch='ftw.solr.EditSearchSettings')
+    directives.omitted('showinsearch')
+    directives.no_omit(IEditForm, 'showinsearch')
+    directives.no_omit(IAddForm, 'showinsearch')
+    showinsearch = Bool(
+        title=_(u'label_showinsearch', default=u'Show in search'),
+        description=u'',
+        default=True)
+
+
+alsoProvides(IShowInSearch, IFormFieldProvider)

--- a/ftw/solr/configure.zcml
+++ b/ftw/solr/configure.zcml
@@ -57,6 +57,16 @@
             for="*"
             />
 
+        <plone:behavior
+            title="Searchwords"
+            provides="ftw.solr.behaviors.ISearchwords"
+            for="*"
+            />
+
+        <adapter
+            factory=".behaviors.searchwords_indexer"
+            name="searchwords" />
+
     </configure>
 
 </configure>

--- a/ftw/solr/configure.zcml
+++ b/ftw/solr/configure.zcml
@@ -5,6 +5,7 @@
     xmlns:five="http://namespaces.zope.org/five"
     xmlns:i18n="http://namespaces.zope.org/i18n"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    xmlns:plone="http://namespaces.plone.org/plone"
     xmlns:zcml="http://namespaces.zope.org/zcml"
     i18n_domain="ftw.solr">
 
@@ -46,5 +47,16 @@
         />
 
     <include package=".upgrades" />
+
+    <configure zcml:condition="installed plone.app.dexterity">
+        <include package="plone.behavior" file="meta.zcml" />
+
+        <plone:behavior
+            title="Show In Search"
+            provides="ftw.solr.behaviors.IShowInSearch"
+            for="*"
+            />
+
+    </configure>
 
 </configure>

--- a/ftw/solr/testing.py
+++ b/ftw/solr/testing.py
@@ -37,7 +37,7 @@ class SolrLayer(PloneSandboxLayer):
         fti = DexterityFTI('DexterityFolder',
                            klass="plone.dexterity.content.Container",
                            global_allow=True)
-        portal.portal_types._setObject('ClassificationFTI', fti)
+        portal.portal_types._setObject('DexterityFolder', fti)
         fti.lookupSchema()
 
 

--- a/ftw/solr/tests/__init__.py
+++ b/ftw/solr/tests/__init__.py
@@ -1,0 +1,16 @@
+from ftw.solr.testing import SOLR_FUNCTIONAL_TESTING
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from unittest2 import TestCase
+import transaction
+
+
+class FunctionalTestCase(TestCase):
+    layer = SOLR_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+
+    def grant(self, *roles):
+        setRoles(self.portal, TEST_USER_ID, list(roles))
+        transaction.commit()

--- a/ftw/solr/tests/test_behaviors.py
+++ b/ftw/solr/tests/test_behaviors.py
@@ -1,0 +1,41 @@
+from ftw.solr.tests import FunctionalTestCase
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import factoriesmenu
+from plone.indexer.interfaces import IIndexer
+from Products.CMFCore.utils import getToolByName
+from zope.component import getMultiAdapter
+import transaction
+
+
+def index_value_for(obj, index_name):
+    catalog = getToolByName(obj, 'portal_catalog')
+    indexer = getMultiAdapter((obj, catalog), IIndexer, name=index_name)
+    return indexer()
+
+
+class TestShowInSearch(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestShowInSearch, self).setUp()
+        portal_types = getToolByName(self.portal, 'portal_types')
+        portal_types['DexterityFolder'].behaviors += (
+            'ftw.solr.behaviors.IShowInSearch', )
+        transaction.commit()
+
+    @browsing
+    def test_True_by_default(self, browser):
+        self.grant('Manager')
+        browser.login().open()
+        factoriesmenu.add('DexterityFolder')
+        browser.click_on('Save')
+        self.assertTrue(index_value_for(browser.context, 'showinsearch'),
+                        'Expected showinsearch to be True by default.')
+
+    @browsing
+    def test_setting_to_False(self, browser):
+        self.grant('Manager')
+        browser.login().open()
+        factoriesmenu.add('DexterityFolder')
+        browser.fill({'Show in search': False}).save()
+        self.assertFalse(index_value_for(browser.context, 'showinsearch'),
+                         'Expected showinsearch to be set to False.')

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ version = '1.5.4.dev0'
 
 tests_require = [
     'ftw.builder',
+    'ftw.testbrowser',
     'plone.app.dexterity',
     'plone.app.testing',
     ]


### PR DESCRIPTION
Adds two new behaviors:

- ftw.solr.behaviors.IShowInSearch
- ftw.solr.behaviors.ISearchwords

These behaviors provide the two fields "show in search" an "searchwords" as they are already existing as schema-extender for Archetypes.