### PR TITLE
Fix faulty upgrade step.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,9 @@ Changelog
 1.6.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix faulty upgrade step which incorrectly added the Solr index queue processor
+  utility in 1.5.0.
+  [mbaechtold]
 
 
 1.6.0 (2016-06-07)

--- a/ftw/solr/upgrades/20150921133623_remove_custom_utilities/componentregistry.xml
+++ b/ftw/solr/upgrades/20150921133623_remove_custom_utilities/componentregistry.xml
@@ -14,7 +14,7 @@
     <utility
       interface="collective.solr.interfaces.ISolrIndexQueueProcessor"
       name="solr"
-      factory="collective.solr.indexerr.SolrIndexProcessor" />
+      factory="collective.solr.indexer.SolrIndexProcessor" />
 
     <utility
       interface="collective.solr.interfaces.ISolrIndexQueueProcessor"


### PR DESCRIPTION
This fixes an existing upgrade step which incorrectly added the Solr index queue processor utility in 1.5.0.