### PR TITLE
Prevent the result text from read out through the screenreader.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 1.6.2 (unreleased)
 ------------------
 
+- Prevent the result text from read out through screenreaders
+  [Kevin Bieri]
+
 - Set searchwords as a non-required field.
   [elioschmutz]
 

--- a/ftw/solr/browser/resources/livesearch.js
+++ b/ftw/solr/browser/resources/livesearch.js
@@ -37,9 +37,19 @@
       results: function( amount ) {
         amount = amount - $(".ui-menu-item .no-result").length;
         if (amount !== 0) {
-          return amount + ( amount > 1 ? $("#search-amount-results-found-message").text() : $("#search-one-result-found-message").text());
+          $("#search-no-results-message").attr("aria-hidden", true);
+          if(amount > 1) {
+            $("#search-amount-results-found-message").attr("aria-hidden", false);
+            return amount + $("#search-amount-results-found-message").text();
+          } else {
+            $("#search-one-result-found-message").attr("aria-hidden", false);
+            return amount + $("#search-one-result-found-message").text();
+          }
 
         } else {
+          $("#search-amount-results-found-message").attr("aria-hidden", true);
+          $("#search-one-result-found-message").attr("aria-hidden", true);
+          $("#search-no-results-message").attr("aria-hidden", false);
           return $("#search-no-results-message").text();
         }
       }

--- a/ftw/solr/viewlets/templates/searchbox.pt
+++ b/ftw/solr/viewlets/templates/searchbox.pt
@@ -46,17 +46,20 @@
         </ul>
 
         <div id="search-no-results-message"
-             i18n:translate="text_search_help_no_results">
+             i18n:translate="text_search_help_no_results"
+             aria-hidden="true">
             No search results.
         </div>
 
         <div id="search-amount-results-found-message"
-             i18n:translate="text_search_results_found">
+             i18n:translate="text_search_results_found"
+             aria-hidden="true">
             results found, use up and down keys to navigate.
         </div>
 
         <div id="search-one-result-found-message"
-             i18n:translate="text_search_one_result_found">
+             i18n:translate="text_search_one_result_found"
+             aria-hidden="true">
             result found, use up and down keys to navigate.
         </div>
 


### PR DESCRIPTION
Closes parts of https://github.com/4teamwork/bern.web/issues/1152
Result text should only be visible to screenreaders if necessary.