### PR TITLE
Abort livesearch init if no searchfield is available

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.6.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Abort livesearch init if no searchfield is available to make the script failsafe.
+  [elioschmutz]
 
 
 1.6.2 (2016-07-15)

--- a/ftw/solr/browser/resources/livesearch.js
+++ b/ftw/solr/browser/resources/livesearch.js
@@ -125,6 +125,8 @@
 
   var init = function() {
     var searchbox = $(".searchField");
+    if (!$(".searchField").length) { return; }
+
     // Always empty on init
     searchbox.val('');
     var widget = $.ui.autocomplete(options, searchbox);


### PR DESCRIPTION
Abort livesearch init if no searchfield is available to make the script failsafe.