### PR TITLE
Allow hyphons and commas simple terms and simple searches.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,9 @@ Changelog
 1.7.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Allow hyphens and commas simple terms and simple searches.
+  Fixes issue where a comma/hyphon in a search term causes search_pattern template to be circumvented.
+  [mathias.leimgruber]
 
 
 1.7.0 (2016-07-22)

--- a/ftw/solr/patches/utils.py
+++ b/ftw/solr/patches/utils.py
@@ -4,7 +4,7 @@
 
 from re import compile, UNICODE
 
-simpleTerm = compile(r'^[\w\d\.]+$', UNICODE)
+simpleTerm = compile(r'^[\w\d\.,-]+$', UNICODE)
 def isSimpleTerm(term):
     if isinstance(term, str):
         term = unicode(term, 'utf-8', 'ignore')
@@ -12,7 +12,7 @@ def isSimpleTerm(term):
 
 
 operators = compile(r'(.*)\s+(AND|OR|NOT)\s+', UNICODE)
-simpleCharacters = compile(r'^[\w\d\?\*\s\.]+$', UNICODE)
+simpleCharacters = compile(r'^[\w\d\?\*\s\.,-]+$', UNICODE)
 def isSimpleSearch(term):
     term = term.strip()
     if isinstance(term, str):

--- a/ftw/solr/tests/test_utils.py
+++ b/ftw/solr/tests/test_utils.py
@@ -16,11 +16,25 @@ class TestIsSimpleSearch(TestCase):
         self.assertTrue(isSimpleSearch('foo.bar'))
         self.assertTrue(isSimpleSearch('foo.bar baz'))
 
+    def test_simple_search_may_contain_commas(self):
+        self.assertTrue(isSimpleSearch('foo,bar'))
+        self.assertTrue(isSimpleSearch('foo-, bar'))
+
+    def test_simple_search_may_contain_hyphon(self):
+        self.assertTrue(isSimpleSearch('foo-bar'))
+        self.assertTrue(isSimpleSearch('foo- bar'))
+
 
 class TestIsSimpleTerm(TestCase):
 
     def test_simple_terms_may_contain_dots(self):
         self.assertTrue(isSimpleTerm('foo.bar'))
+
+    def test_simple_terms_may_contain_commas(self):
+        self.assertTrue(isSimpleTerm('foo,bar'))
+
+    def test_simple_terms_may_contain_hyphon(self):
+        self.assertTrue(isSimpleTerm('foo-bar'))
 
     def test_simple_terms_may_contain_digits(self):
         self.assertTrue(isSimpleTerm('foo7bar'))


### PR DESCRIPTION
Fixes issue where a comma/hyphon in a search term causes search_pattern template to be circumvented.

Also check PR https://github.com/4teamwork/ftw.solr/pull/45
Same issue with dots.

cc @jone 