### PR TITLE
Avoid AttributeError "solr_response" on solr errors.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 1.8.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Avoid AttributeError "solr_response" on solr errors. [jone]
 
 
 1.8.0 (2016-10-31)

--- a/ftw/solr/browser/search.py
+++ b/ftw/solr/browser/search.py
@@ -79,6 +79,7 @@ class SearchView(browser.Search):
         """Get properly wrapped search results from the catalog.
         'query' should be a dictionary of catalog parameters.
         """
+        self.solr_response = []
         # Disable theming for ajax requests
         if 'ajax' in self.request.form:
             del self.request.form['ajax']


### PR DESCRIPTION
When an exception is raised while querying, the solr_response attribute was not set but later accessed by the template.
By setting it by default to an empty list we make sure that we do not produce unecessary AttributeErrors.
