### PR TITLE
Fix html entities in querystring. This produced strange js errors.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 1.8.2 (unreleased)
 ------------------
 
+- Scan for external links after every search page refresh.
+  [mathias.leimgruber]
+
 - Do not use TALES string expressions for facet links, since it automatically transforms
   chars into html entities. 
   The facet links were like "&amp;amp;amp;amp;" every time you add/remove a facet.

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,11 @@ Changelog
 1.8.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Do not use TALES string expressions for facet links, since it automatically transforms
+  chars into html entities. 
+  The facet links were like "&amp;amp;amp;amp;" every time you add/remove a facet.
+  Since we have three facts by default this happened tree times on every click.
+  [mathias.leimgruber]
 
 
 1.8.1 (2016-11-04)

--- a/ftw/solr/browser/available-facets.pt
+++ b/ftw/solr/browser/available-facets.pt
@@ -20,7 +20,7 @@
             tal:attributes="id string: ${repeat/facet/index}_filter">
             <li tal:repeat="item facet_counts">
                 <a href="#" class="facet" tal:content="string:${item/title} (${item/count})"
-                   tal:attributes="href string:${request/ACTUAL_URL}?${item/query}" />
+                   tal:attributes="href python:request.ACTUAL_URL + '?' + item['query']" />
             </li>
         </ul>
       </div>

--- a/ftw/solr/browser/search.js
+++ b/ftw/solr/browser/search.js
@@ -26,6 +26,12 @@ jQuery(function ($) {
                 useLocation: false,
                 useReferrer: false
             });
+
+            try {
+              scanforlinks();
+            } catch(err) {
+              // Ignore - may be the feature is disabled
+            }
         });
     });
 

--- a/ftw/solr/browser/selected-facets.pt
+++ b/ftw/solr/browser/selected-facets.pt
@@ -14,7 +14,7 @@
             <span class="facetItemValue"
                   tal:content="item/value" />
             <a class="facetRemoveItem"
-               tal:attributes="href string:${request/ACTUAL_URL}?${item/query}"
+               tal:attributes="href python:request.ACTUAL_URL + '?' + item['query']"
                i18n:translate="">Remove this search limit...</a>
         </li>
     </ul>


### PR DESCRIPTION
Do not use TALES string expressions for facet links, since it automatically transforms chars into html entities.

This fixes several JS problems + re-enabled the search highlight feature of the search function.

I also call now the "scanforlinks" (mark_special_link.js) method to mark the external links (external resources).
