### PR TITLE
Make getting the facets more robust.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,9 @@ Changelog
 1.8.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Make getting the facets more robust which caused projects having customizations
+  of selected facets to crash when displaying the search results.
+  [mbaechtold]
 
 
 1.8.3 (2016-12-15)

--- a/ftw/solr/browser/facets.py
+++ b/ftw/solr/browser/facets.py
@@ -105,7 +105,7 @@ class SearchFacetsView(facets.SearchFacetsView):
            this assumes that facets are selected using filter queries."""
         info = []
         facets = param(self, 'facet.field')
-        facet_queries = self.facet_queries()
+        facet_queries = self.facet_queries() or []
         fq = param(self, 'fq')
         for idx, query in enumerate(fq):
             field, value = query.split(':', 1)


### PR DESCRIPTION
This prevents projects having customizations of selected facets from crashing when displaying the search results.