### PR TITLE
Fix font for livesearch results

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.8.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix font for livesearch results.
+  [Kevin Bieri]
 
 
 1.8.2 (2016-11-24)
@@ -14,7 +15,7 @@ Changelog
   [mathias.leimgruber]
 
 - Do not use TALES string expressions for facet links, since it automatically transforms
-  chars into html entities. 
+  chars into html entities.
   The facet links were like "&amp;amp;amp;amp;" every time you add/remove a facet.
   Since we have three facts by default this happened tree times on every click.
   [mathias.leimgruber]

--- a/ftw/solr/browser/resources/livesearch.scss
+++ b/ftw/solr/browser/resources/livesearch.scss
@@ -1,3 +1,8 @@
+.ui-widget {
+  font-family: $font-family-primary;
+  font-size: em($font-size-base);
+}
+
 .LSBox {
   .ui-autocomplete {
     @include screen-small {
@@ -58,6 +63,7 @@
 
       &:before {
         float: left;
+        text-align: left;
       }
 
       &.ui-state-focus {


### PR DESCRIPTION
Closes https://github.com/4teamwork/ftw.solr/issues/85

The font has been set through the standard jqueryUI styling.
But we want the predefined font settings from ftw.theming.