### PR TITLE
Lower searchwords in ISearchwords indexer, since the value is always lowered in ftw.solr.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ------------------
 
 - Lower searchwords in ISearchwords indexer, since the value is always lowered in ftw.solr.
+  This applies only for DX content.
   [mathias.leimgruber]
 
 - Fix font for livesearch results.

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 1.8.5 (unreleased)
 ------------------
 
+- Lower searchwords in ISearchwords indexer, since the value is always lowered in ftw.solr.
+  [mathias.leimgruber]
+
 - Fix font for livesearch results.
   [Kevin Bieri]
 

--- a/ftw/solr/behaviors.py
+++ b/ftw/solr/behaviors.py
@@ -69,4 +69,5 @@ def searchwords_indexer(obj):
     if not isinstance(words, unicode):
         words = words.decode('utf-8')
 
-    return filter(None, [word.strip('\r ') for word in words.split('\n')])
+    return filter(None,
+                  [word.strip('\r ').lower() for word in words.split('\n')])

--- a/ftw/solr/tests/test_behaviors.py
+++ b/ftw/solr/tests/test_behaviors.py
@@ -26,7 +26,6 @@ def disable_behavior(behavior, type='DexterityFolder'):
     transaction.commit()
 
 
-
 class TestShowInSearch(FunctionalTestCase):
 
     def setUp(self):
@@ -73,5 +72,5 @@ class TestSearchwords(FunctionalTestCase):
         factoriesmenu.add('DexterityFolder')
         browser.fill({'Search words': 'Foo Bar\nBaz'}).save()
         browser.open(browser.context, view='edit')
-        self.assertEquals([u'Foo Bar', u'Baz'],
+        self.assertEquals([u'foo bar', u'baz'],
                           index_value_for(browser.context, 'searchwords'))

--- a/ftw/solr/tests/test_indexers.py
+++ b/ftw/solr/tests/test_indexers.py
@@ -104,3 +104,30 @@ class TestSnippetText(TestCase):
         doc = DummyType()
         wrapped = IndexableObjectWrapper(doc, portal.portal_catalog)
         self.assertEquals(" SearchableText", wrapped.snippetText)
+
+    def test_searchwords_are_index_lowered(self):
+        from Products.CMFCore.interfaces import IContentish
+        from zope.interface import implements
+        from ftw.solr.behaviors import ISearchwords
+
+        class DummyType(object):
+            implements(IContentish, ISearchwords)
+
+            def SearchableText(self_):
+                return "Dummy SearchableText"
+
+            def Title(self_):
+                return "Dummy"
+
+            @property
+            def searchwords(self_):
+                return u"Spam\nEggs"
+
+            def Schema(self_):
+                self.fail("Not an archetypes object.")
+
+        portal = self.layer['portal']
+        doc = DummyType()
+
+        wrapped = IndexableObjectWrapper(doc, portal.portal_catalog)
+        self.assertEquals([u'spam', u'eggs'], wrapped.searchwords)

--- a/ftw/solr/upgrades/20170403110134_update_searchwords_index/upgrade.py
+++ b/ftw/solr/upgrades/20170403110134_update_searchwords_index/upgrade.py
@@ -1,0 +1,18 @@
+from ftw.solr.behaviors import ISearchwords
+from ftw.upgrade import UpgradeStep
+from plone.dexterity.interfaces import IDexterityContent
+
+
+class UpdateSearchwordsIndex(UpgradeStep):
+    """Update searchwords index.
+    """
+
+    def __call__(self):
+        query = {'object_provides': {
+            'query': [ISearchwords.__identifier__,
+                      IDexterityContent.__identifier__],
+            'operator': 'and'}}
+        for obj in self.objects(query, 'Update searchwords index'):
+            if ISearchwords(obj).searchwords:
+                obj.reindexObject(idxs=['searchwords'])
+        self.install_upgrade_profile()


### PR DESCRIPTION
This applies only for DX content. 