### PR TITLE
Hide and order the viewlets for all skins and not only for the "Sunburst Theme"-skin

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.8.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Hide and order the viewlets for all skins and not only for the "Sunburst Theme"-skin
+  [elioschmutz]
 
 
 1.8.5 (2017-04-19)

--- a/ftw/solr/profiles/default/viewlets.xml
+++ b/ftw/solr/profiles/default/viewlets.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
 <object>
 
-    <order manager="plone.portalheader" skinname="Sunburst Theme">
+    <order manager="plone.portalheader" skinname="*">
         <viewlet name="ftw.solr.searchbox" insert-after="plone.searchbox"/>
     </order>
 
-    <hidden manager="plone.portalheader" skinname="Sunburst Theme">
+    <hidden manager="plone.portalheader" skinname="*">
         <viewlet name="plone.searchbox" />
     </hidden>
 


### PR DESCRIPTION
The current `viewlets.xml` only orders and hides the viewlets for the "Sunburst Theme"-skin. If you use another skin and you install `ftw.solr` you wont get the desired viewlet-changes.

