### PR TITLE
Prevent invalid url if the object has a get parameter in his path.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,9 @@ Changelog
 - Hide and order the viewlets for all skins and not only for the "Sunburst Theme"-skin
   [elioschmutz]
 
+- Prevent invalid url if the object has a get parameter in his path.
+  [lknoepfel]
+
 
 1.8.5 (2017-04-19)
 ------------------

--- a/ftw/solr/contentlisting.py
+++ b/ftw/solr/contentlisting.py
@@ -53,7 +53,8 @@ class SolrContentListingObject(catalog.CatalogContentListingObject):
             url, anchor = url.split('#')
         url = url + self.appendViewAction()
         if search_term:
-            url = url + '?searchterm=' + urllib.quote(search_term)
+            separator = '&' if '?' in url else '?'
+            url = url + separator + 'searchterm=' + urllib.quote(search_term)
         if anchor:
             url = url + '#' + anchor
         return url

--- a/ftw/solr/tests/test_searchview.py
+++ b/ftw/solr/tests/test_searchview.py
@@ -227,6 +227,26 @@ class TestSearchView(TestCase):
         view = getMultiAdapter((portal, request), name=u'search')
         self.assertEquals([], view.suggestions())
 
+    def test_appended_searchterm_does_preserve_a_valid_url(self):
+        portal = self.layer['portal']
+        request = self.layer['request']
+
+        # Setup browser layers
+        notify(BeforeTraverseEvent(portal, request))
+
+        flare = PloneFlare(portal)
+        flare.request = request
+        flare.getURL = lambda: 'http://nohost/plone/object?this=that#ananans'
+        request.form['SearchableText'] = 'test'
+
+        content_listing = IContentListingObject(flare)
+        # patch away non-relevant check
+        content_listing.is_external = lambda: True
+
+        self.assertEqual(
+            content_listing.result_url(),
+            'http://nohost/plone/object?this=that&searchterm=test#ananans')
+
 
 class TestPrepareSearchableText(TestCase):
 


### PR DESCRIPTION
If we use the live search and the result has a `GET` parameter in his URL then `ftw.solr` generates an invalid URL with two `?`. Example `http://nohost/plone/object?this=that?searchterm=test`

This PR handles this edge-case.

Extranet Ticket: https://extranet.4teamwork.ch/support/stadt-winterthur/tracker-web/27