### PR TITLE
escape less than and greater than sign

### DIFF
--- a/ftw/solr/indexers.py
+++ b/ftw/solr/indexers.py
@@ -81,5 +81,6 @@ class SnippetTextIndexer(object):
 
         # Strip html tags
         text = re.sub('<[^<]+?>', '', text)
-
+        text = text.replace('<', '&lt;')
+        text = text.replace('>', '&gt;')
         return text

--- a/ftw/solr/upgrades/20170531122255_reindex_snippet_text/upgrade.py
+++ b/ftw/solr/upgrades/20170531122255_reindex_snippet_text/upgrade.py
@@ -1,0 +1,17 @@
+from ftw.upgrade import UpgradeStep
+from collective.solr.interfaces import ISearch
+from zope.component import getUtility
+
+class ReindexSnippetText(UpgradeStep):
+    """Reindex snippet text.
+    """
+
+    def __call__(self):
+        search = getUtility(ISearch)
+        objs = search.search('snippetText: *<*')
+        for item in objs.results():
+            self.portal.restrictedTraverse(item.path_string +
+                                           '/solr-maintenance/reindex')(
+                limit=1,
+                idxs=['snippetText'])
+        self.install_upgrade_profile()


### PR DESCRIPTION
This fixes the Problem where the < sign is not escaped and leads to the footer being displayed twice.
The upgrade step is very general since it could be a issue on a lot of types. But i'm not sure if its a good idea to put it as general since it could be quite expensive to run.