### PR TITLE
Remove search viewlet submit from tabindex.

### DIFF
--- a/ftw/solr/viewlets/templates/searchbox.pt
+++ b/ftw/solr/viewlets/templates/searchbox.pt
@@ -25,6 +25,7 @@
                class="searchField" />
 
         <input class="searchButton"
+               tabindex="-1"
                type="submit"
                value="Search"
                i18n:attributes="value label_search;" />


### PR DESCRIPTION
Previously the submit was like a hidden tabindex after the search box. The user can still submit from the search input.