### PR TITLE
Fix position of facet closing icon.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.9.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix position of facet closing icon.
+  [mbaechtold]
 
 
 1.9.2 (2017-08-08)

--- a/ftw/solr/browser/resources/searchpage.scss
+++ b/ftw/solr/browser/resources/searchpage.scss
@@ -128,23 +128,22 @@
     > .facetItemTitle {
       font-weight: bold;
     }
+
+    > .facetRemoveItem {
+      @extend .fa-icon;
+      @extend .fa-remove;
+      padding: 0;
+      display: inline-block;
+      color: $color-danger;
+      font-size: 0;
+      line-height: normal;
+
+      &:before {
+        font-size: $font-size-base;
+      }
+    }
   }
 }
-
-.facetRemoveItem {
-  @extend .fa-icon;
-  @extend .fa-remove;
-  padding: 0;
-  display: inline-block;
-  color: $color-danger;
-  font-size: 0;
-
-  &:before {
-    font-size: $font-size-base;
-  }
-}
-
-
 
 #notFoundSuggestions {
   @include clearfix;


### PR DESCRIPTION
The selector must be more explicit, otherwise the `list()` mixin wins.

## Before

<img width="1003" alt="screenshot vorher" src="https://user-images.githubusercontent.com/28220/29621222-6e86d526-8820-11e7-90d5-9fe1d82cc3f3.png">

## After

<img width="756" alt="screenshot nachher" src="https://user-images.githubusercontent.com/28220/29621234-7509b148-8820-11e7-9d48-e72c0ec18f31.png">