### PR TITLE
Use searchform action as endpoint in search.js.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.9.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Use searchform action as endpoint in search.js.
+  [mathias.leimgruber]
 
 
 1.9.3 (2017-08-28)

--- a/ftw/solr/browser/search.js
+++ b/ftw/solr/browser/search.js
@@ -14,7 +14,8 @@ jQuery(function ($) {
         var State = History.getState();
         var qs = State.url.replace(/^.*\?/, '') + '&ajax=1';
         var results_container = $('#search-results-wrapper');
-        $.get('@@search', qs, function(data) {
+        var endpoint = $('#searchform');
+        $.get(endpoint.attr('action'), qs, function(data) {
             results_container.hide();
             var $data = $(data);
             $('#portal-searchfacets').html($data.find('#portal-searchfacets').html());


### PR DESCRIPTION
This means we can use a copy of the search view with a different endpoint and we can still use the same js.