### PR TITLE
Always quote values of a list query containing an operator.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 1.9.4 (unreleased)
 ------------------
 
+- Always quote values of a list containing an operator.
+  [mathias.leimgruber]
+
 - Use searchform action as endpoint in search.js.
   [mathias.leimgruber]
 

--- a/ftw/solr/patches/mangler.py
+++ b/ftw/solr/patches/mangler.py
@@ -145,7 +145,7 @@ def mangleQuery(keywords, config, schema):
         elif 'operator' in args:
             if isinstance(value, (list, tuple)) and len(value) > 1:
                 sep = ' %s ' % args['operator'].upper()
-                value = sep.join(map(str, map(iso8601date, value)))
+                value = sep.join(map(lambda item: '"'+str(item)+'"', map(iso8601date, value)))
                 keywords[key] = '(%s)' % value
             del args['operator']
         elif key == 'allowedRolesAndUsers':


### PR DESCRIPTION

portal_catalog query: `{'Subject': {'query':['Tag 1', 'Tag 2], 'operator': 'and'}`
Now results in `+Subject:("Tag 1" AND "Tag 2")`

Before the result was `+Subject:(Tag 1 AND Tag 2)`

This way solr search for `Tag AND 1 AND Tag AND 2`