### PR TITLE
Fix escaping issue when highlighting plaintext.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,8 @@ Changelog
 1.9.4 (unreleased)
 ------------------
 
+- Fix escaping issue when highlighting plaintext. [jone]
+
 - Always quote values of a list containing an operator.
   [mathias.leimgruber]
 

--- a/ftw/solr/tests/test_searchview.py
+++ b/ftw/solr/tests/test_searchview.py
@@ -247,6 +247,30 @@ class TestSearchView(TestCase):
             content_listing.result_url(),
             'http://nohost/plone/object?this=that&searchterm=test#ananans')
 
+    def test_breadcrumbs(self):
+        """We get mixed html and plaintext form solr and need to escape the
+        text. The only html we get is <em> and </em>, so we should only keep
+        that unescaped.
+        """
+        portal = self.layer['portal']
+        request = self.layer['request']
+        view = getMultiAdapter((portal, request), name=u'search')
+        self.assertEquals(
+            '&lt;a&gt;foo&lt;/a&gt;',
+            view.escape_snippet_text('<a>foo</a>'))
+
+        self.assertEquals(
+            'a &amp; b',
+            view.escape_snippet_text('a & b'))
+
+        self.assertEquals(
+            'foo &lt; <em>bar</em>',
+            view.escape_snippet_text('foo < <em>bar</em>'))
+
+        self.assertEquals(
+            '1 <em>foo</em> 2 <em>foo</em> 3',
+            view.escape_snippet_text('1 <em>foo</em> 2 <em>foo</em> 3'))
+
 
 class TestPrepareSearchableText(TestCase):
 


### PR DESCRIPTION
Problem:
Solr returns `<em>`-highlighted text, but the text is not html escaped.
Using "<" for example can cause the page templating engine to drop
closing tags.

Solution:
Escape all text in the snippet endpoint, except for the highlighting
`<em>`-tags.