### PR TITLE
Fix broken html-markup in available-facets.pt.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.10.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix broken html-markup in available-facets.pt.
+  [elioschmutz]
 
 
 1.10.0 (2017-11-28)

--- a/ftw/solr/browser/available-facets.pt
+++ b/ftw/solr/browser/available-facets.pt
@@ -17,7 +17,7 @@
         <ul class="facets"
             tal:condition="facet_counts"
             aria-hidden="true"
-            tal:attributes="id string: ${repeat/facet/index}_filter">
+            tal:attributes="id string:${repeat/facet/index}_filter">
             <li tal:repeat="item facet_counts">
                 <a href="#" class="facet" tal:content="string:${item/title} (${item/count})"
                    tal:attributes="href python:request.ACTUAL_URL + '?' + item['query']" />


### PR DESCRIPTION
This PR fixes a broken Markup in the HTML. The ID contains a whitespace which makes it hard to select it with a query-selector in js.