### PR TITLE
Fix bad return value for facet infos.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 1.10.1 (unreleased)
 -------------------
 
+- Fix bad return value for facet infos.
+  [elioschmutz]
+
 - Fix disallowed html tag id name.
   [elioschmutz]
 

--- a/ftw/solr/browser/facets.py
+++ b/ftw/solr/browser/facets.py
@@ -44,7 +44,10 @@ class SearchFacetsView(facets.SearchFacetsView):
 
     def facets(self):
         """Prepare and return facetting info for the given SolrResponse """
-        info = super(SearchFacetsView, self).facets()
+
+        # Facets should always return a list. But it returns None if there are no
+        # facets. This will cause problems because of inconsistent types.
+        info = super(SearchFacetsView, self).facets() or []
         facet_queries = self.facet_queries()
         if not facet_queries:
             return info


### PR DESCRIPTION
This PR fixes a bad return value from `collective.solr`s `facets`-function.

We always need a `list` for the `info` variable. Otherwise we cannot append more items further in the script.