### PR TITLE
Improve error logging

### DIFF
--- a/ftw/solr/connection.py
+++ b/ftw/solr/connection.py
@@ -126,8 +126,10 @@ class SolrConnection(object):
                     resp = self.post(
                         '/update/extract?%s' % urlencode(params, doseq=True))
                     if not resp.is_ok():
-                        logger.error('Extract command for blob %s failed. %s',
-                                     file_, resp.error_msg())
+                        logger.error(
+                            'Extract command for UID=%s with blob %s failed. '
+                            '%s',
+                            data.get(u'UID'), file_, resp.error_msg())
             if extract_after_commit:
                 transaction.get().addAfterCommitHook(
                     hook, args=[self.extract_commands])

--- a/ftw/solr/tests/test_connection.py
+++ b/ftw/solr/tests/test_connection.py
@@ -94,7 +94,7 @@ class TestConnection(unittest.TestCase):
         conn.add({'id': '1'})
         conn.flush()
         conn.post.assert_called_once_with(
-            '/update', data='{"add": {"doc": {"id": "1"}}}')
+            '/update', data='{"add": {"doc": {"id": "1"}}}', log_error=False)
         self.assertEqual(conn.update_commands, [])
 
     def test_flush_operation_posts_extract_commands_and_clears_queue(self):
@@ -106,7 +106,7 @@ class TestConnection(unittest.TestCase):
         tr.commit()
         conn.post.assert_called_once_with(
             '/update/extract?literal.id=1&commitWithin=10000'
-            '&stream.file=%2Ffolder%2Ffile')
+            '&stream.file=%2Ffolder%2Ffile', log_error=False)
         self.assertEqual(conn.extract_commands, [])
 
     def test_flush_operation_without_after_commit_hook(self):
@@ -116,7 +116,7 @@ class TestConnection(unittest.TestCase):
         conn.flush(extract_after_commit=False)
         conn.post.assert_called_once_with(
             '/update/extract?literal.id=1&commitWithin=10000'
-            '&stream.file=%2Ffolder%2Ffile')
+            '&stream.file=%2Ffolder%2Ffile', log_error=False)
         self.assertEqual(conn.extract_commands, [])
 
     def test_extract_with_boolean_query_params(self):


### PR DESCRIPTION
Log UID when blob extraction fails to allow easier lookup of the content object.
Only log response errors from update and extract commands once.