### PR TITLE
Declare dependency on plone.namedfile[blobs]

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Declare dependency on plone.namedfile[blobs].
+  [lgraf]
 
 
 2.0.0 (2018-02-15)

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
         'collective.indexing',
         'plone.app.contentlisting',
         'plone.app.layout',
+        'plone.namedfile[blobs]',
     ],
     extras_require=dict(test=tests_require, tests=tests_require),
     entry_points="""


### PR DESCRIPTION
Declare dependency on `plone.namedfile[blobs]`, as [`ftw.solr` currently requires it](https://github.com/4teamwork/ftw.solr/blob/3b14cac8cbbee369b03977267288fba683026420/ftw/solr/handlers.py#L6) (could be made a soft dependency in the future).