### PR TITLE
Solr 7.3 compatibility: Fix requests to ExtractingRequestHandler

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,9 @@ Changelog
 2.1.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Set Content-Type 'application/x-www-form-urlencoded' for requests to
+  /update/extract endpoint to ensure compatibility with Solr 7.3.
+  [lgraf]
 
 
 2.1.1 (2018-02-20)

--- a/ftw/solr/connection.py
+++ b/ftw/solr/connection.py
@@ -62,12 +62,13 @@ class SolrConnection(object):
                 self.reconnect_before_request = False
                 return SolrResponse(exception=exc, log_error=log_error)
 
-    def post(self, path, data=None, log_error=True):
+    def post(self, path, data=None, headers={}, log_error=True):
+        headers = headers if headers else self.post_headers
         return self.request(
-            'POST', path, data, self.post_headers, log_error=log_error)
+            'POST', path, data, headers, log_error=log_error)
 
-    def get(self, path, log_error=True):
-        return self.request('GET', path, log_error=log_error)
+    def get(self, path, headers={}, log_error=True):
+        return self.request('GET', path, headers=headers, log_error=log_error)
 
     def reconnect(self):
         self.conn.close()
@@ -126,6 +127,7 @@ class SolrConnection(object):
                     params['commitWithin'] = '10000'
                     resp = self.post(
                         '/update/extract?%s' % urlencode(params, doseq=True),
+                        headers={'Content-Type': 'application/x-www-form-urlencoded'},  # noqa
                         log_error=False)
                     if not resp.is_ok():
                         logger.error(

--- a/ftw/solr/tests/test_connection.py
+++ b/ftw/solr/tests/test_connection.py
@@ -106,7 +106,9 @@ class TestConnection(unittest.TestCase):
         tr.commit()
         conn.post.assert_called_once_with(
             '/update/extract?literal.id=1&commitWithin=10000'
-            '&stream.file=%2Ffolder%2Ffile', log_error=False)
+            '&stream.file=%2Ffolder%2Ffile',
+            headers={'Content-Type': 'application/x-www-form-urlencoded'},
+            log_error=False)
         self.assertEqual(conn.extract_commands, [])
 
     def test_flush_operation_without_after_commit_hook(self):
@@ -116,7 +118,9 @@ class TestConnection(unittest.TestCase):
         conn.flush(extract_after_commit=False)
         conn.post.assert_called_once_with(
             '/update/extract?literal.id=1&commitWithin=10000'
-            '&stream.file=%2Ffolder%2Ffile', log_error=False)
+            '&stream.file=%2Ffolder%2Ffile',
+            headers={'Content-Type': 'application/x-www-form-urlencoded'},
+            log_error=False)
         self.assertEqual(conn.extract_commands, [])
 
     def test_extract_with_boolean_query_params(self):


### PR DESCRIPTION
Set the`application/x-www-form-urlencoded` Content-Type for requests to the `/update/extract` endpoint to ensure compatibility with Solr 7.3.

This is needed because something suble changed from Solr 7.2 to 7.3 where the `/update/extract` endpoint now requires you to either set the `application/x-www-form-urlencoded` content type or use a `GET` instead of a `POST` in order for it to honor the `stream.file` parameter.

With just a `POST` and no urlencoded content type, 7.3 will attempt to read the content stream from the POST body (ignoring `stream.file`), resulting in an empty stream being passed to Tika for extraction. This will then cause Tika to fail with a `ZeroByteFileException`.

I tested this invocation of the ExtractingRequestHandler for both Solr 7.2 and 7.3, so it works for both.

---

Alternatively, just switching from POST to GET also does the trick (and also works for both 7.2 and 7.3). The [documentation on Content Stream Sources](https://lucene.apache.org/solr/guide/7_3/content-streams.html#ContentStreams-StreamSources) isn't entirely clear on whether GET or POST should be used if `stream.file` is the intended stream source, so I went with setting the `application/x-www-form-urlencoded` header because the documentation is slightly less ambiguous on that.