### PR TITLE
Fix use of highlightSearchTerms on livesearch if searching for multiple terms.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,10 @@ Changelog
 1.10.1 (unreleased)
 -------------------
 
+- Fix use of highlightSearchTerms on livesearch if searching for multiple terms.
+  jquery.highlightsearchterms needs a list of searchterms to work properly.
+  [elioschmutz]
+
 - Fix bad return value for facet infos.
   [elioschmutz]
 

--- a/ftw/solr/browser/search.js
+++ b/ftw/solr/browser/search.js
@@ -5,7 +5,7 @@ jQuery(function ($) {
         // If there's a history hash get the parameter from there.
         var search = History.getHash() ? History.getHash() : window.location.search;
         var match = RegExp('[?&]' + name + '=([^&]*)').exec(search);
-        return match && decodeURIComponent(match[1].replace(/\+/g, ' '));
+        return match && decodeURIComponent(match[1].replace(/\+/g, ' ')).split(' ');
     }
 
     var History = window.History;


### PR DESCRIPTION
This PR fixes an issue where searchterms haven't been highlighted properly:

Before:

![screen1](https://user-images.githubusercontent.com/557005/42618533-947faf44-85b5-11e8-9c06-04ab3389ebd9.gif)

After:

![screen2](https://user-images.githubusercontent.com/557005/42618546-a1459892-85b5-11e8-8ab2-37e81094d682.gif)



Issuer: https://extranet.4teamwork.ch/support/ivbe/tracker/125
