### PR TITLE
Remove duplicated array after splitting searchable text in highlightS…

### DIFF
--- a/ftw/solr/browser/search.js
+++ b/ftw/solr/browser/search.js
@@ -23,7 +23,7 @@ jQuery(function ($) {
             $('h1.documentFirstHeading').html($data.find('h1.documentFirstHeading').html());
             results_container.fadeIn(200);
             results_container.find('.searchResults').highlightSearchTerms({
-                terms: [getParameterByName('SearchableText')],
+                terms: getParameterByName('SearchableText'),
                 useLocation: false,
                 useReferrer: false
             });


### PR DESCRIPTION
Fix highlightSearchTerms => since we're returning an array of search-terms, we don't need to convert the searchterms in an array again 🙈 

Follow-up of https://github.com/4teamwork/ftw.solr/pull/120