### PR TITLE
Patch reindexObjectSecurity to optimize indexing of large trees.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -1,8 +1,11 @@
 Changelog
 =========
 
-2.2.1 (unreleased)
+2.3.0 (unreleased)
 ------------------
+
+- Patch reindexObjectSecurity to optimize indexing of large trees.
+  [lgraf]
 
 - Fix diff for items with a modification date that has no fractional seconds.
   [buchi]

--- a/ftw/solr/__init__.py
+++ b/ftw/solr/__init__.py
@@ -1,0 +1,2 @@
+def initialize(context):
+    from ftw.solr import patches  # noqa

--- a/ftw/solr/configure.zcml
+++ b/ftw/solr/configure.zcml
@@ -3,11 +3,18 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
     xmlns:i18n="http://namespaces.zope.org/i18n"
     xmlns:plone="http://namespaces.plone.org/plone"
+    xmlns:five="http://namespaces.zope.org/five"
     i18n_domain="ftw.solr">
+
+  <five:registerPackage package="." initialize=".initialize" />
 
   <!-- Dependencies -->
   <include package="plone.app.layout" />
   <include package="plone.app.contentlisting" />
+
+  <!-- Load collective.indexing's ZCML to make sure its Catalog patches are
+  applied before ftw.solr's -->
+  <include package="collective.indexing" />
 
   <include package=".browser" />
 

--- a/ftw/solr/patches.py
+++ b/ftw/solr/patches.py
@@ -1,0 +1,161 @@
+from collective.indexing import monkey  # noqa
+from Products.Archetypes.CatalogMultiplex import CatalogMultiplex
+from Products.CMFCore.CMFCatalogAware import CMFCatalogAware
+from plone.indexer.interfaces import IIndexer
+from Products.Archetypes.config import TOOL_NAME
+from Products.Archetypes.utils import isFactoryContained
+from Products.CMFCore.interfaces import ICatalogTool
+from Products.CMFCore.interfaces._content import ICatalogAware
+from Products.CMFCore.utils import getToolByName
+from zope.component import queryMultiAdapter
+
+
+def is_index_value_equal(old, new):
+    """Compares an old and a new index value.
+    If the value is of type list, it is compared as set since this usually is
+    used in a KeywordIndex, where the order is not relevant.
+    """
+    if type(old) != type(new):
+        return False
+    if isinstance(old, list):
+        return set(old) == set(new)
+    return old == new
+
+
+def is_index_up_to_date(catalog, obj, index_name):
+    """Checks whether the passed index (`index_name`) of the passed object
+    (`obj`) is up to date in the passed catalog (`catalog`).
+    """
+    indexer = queryMultiAdapter((obj, catalog), IIndexer, name=index_name)
+    if indexer is None:
+        indexer = getattr(obj, index_name, None)
+
+    if indexer is None:
+        # We cannot re-generate the index data, therfore we
+        # act as if it is outdated
+        return False
+
+    else:
+        path = '/'.join(obj.getPhysicalPath())
+        rid = catalog.getrid(path)
+        if rid is None:
+            # the object was not yet indexed
+            return False
+
+        indexed_values = catalog.getIndexDataForRID(catalog.getrid(path))
+        value_before = indexed_values.get(index_name, None)
+        value_after = indexer()
+        if not is_index_value_equal(value_before, value_after):
+            return False
+
+    return True
+
+
+def recursive_index_security(catalog, obj, skip_self=False):
+    """This function recursively reindexes the security indexes for an object
+    in a specific catalog.
+
+    It does so by walking down the tree and checking for every object whether
+    its security indexes are already up to date. If they are up to date, it
+    stops recursion.
+
+    The aim of terminating recursion early is to drastically improve
+    performance for large trees. This also avoids unnecessarily reindexing the
+    same objects multiple times if this function is called for several
+    overlapping subtrees.
+
+    Reasoning why terminating recursion early is safe:
+    --------------------------------------------------
+
+    CMFCatalogAware.reindexObjectSecurity() needs to be recursive because
+    changes to an object's security may affect contained subobjects.
+
+    Indexed security for objects in Plone can only be influenced by their
+    parents via some kind of inheritance. There's exactly two inheritance
+    mechanisms in play:
+
+    - Acquisition of permissions via the obj's security settings (manage_access)
+    - Inheritance of local roles
+
+    (An obj's security settings can indirectly be managed via workflows. This
+    doesn't matter here though, it's irrelevant how exactly they came to be).
+
+    In both of these cases, only the immediate parent of a subobject is
+    relevant for inheritance. Therefore, if an objects indexed security didn't
+    experience any changes, neither can any of its subobjects - recursively.
+
+    Because of this, downstream propagation can be stopped as soon as an
+    object is encountered whose indexed security didn't change.
+
+    ---
+
+    In the case of workflow changes, reindexObjectSecurity() still needs to
+    be called for every object that is *directly* affected by the change:
+
+    - switched to a different WF
+    - to a different WF state
+    - changes in the WF state's security settings
+    - object moved to/out of a placeful WF).
+
+    Identifying these objects is usually easy, and you can't and must not rely
+    on reinexObjectSecurity's recursion to pick them up. Instead, they can be
+    determined by querying for the relevant criteria, e.g. objects that have
+    a particular WF.
+
+    Recursion will then take care of updating security indexes for affected
+    subobjects that *don't* meet the criteria for being directly affected (
+    like subobjects with a different workflow).
+    """
+    indexes_to_update = []
+
+    # Since objectValues returns all objects, including placefulworkflow policy
+    # objects, we have to check if the object is Catalog aware.
+    if not ICatalogAware.providedBy(obj):
+        return
+
+    for index_name in obj._cmf_security_indexes:
+        if not is_index_up_to_date(catalog, obj, index_name):
+            indexes_to_update.append(index_name)
+
+    if indexes_to_update:
+        if not skip_self:
+            obj.reindexObject(idxs=indexes_to_update)
+
+        # We assume that if the parent is up to date, all children are too.
+        # Therefore we stop recursion as soon as we encounter an object
+        # whose security indexes are up to date.
+        for subobj in obj.objectValues():
+            recursive_index_security(catalog, subobj)
+
+
+def ftw_solr_CatalogMultiplex_reindexObjectSecurity(self, skip_self=False):
+    """Update security information in all registered catalogs.
+    """
+    if isFactoryContained(self):
+        return
+    at = getToolByName(self, TOOL_NAME, None)
+    if at is None:
+        return
+
+    catalogs = [c for c in at.getCatalogsByType(self.meta_type)
+                if ICatalogTool.providedBy(c)]
+
+    for catalog in catalogs:
+        recursive_index_security(catalog, self, skip_self=skip_self)
+
+
+def ftw_solr_CatalogAware_reindexObjectSecurity(self, skip_self=False):
+    """Reindex security-related indexes on the object.
+    """
+    catalog = self._getCatalogTool()
+    if catalog is None:
+        return
+
+    s = getattr(self, '_p_changed', 0)
+    recursive_index_security(catalog, self, skip_self=skip_self)
+    if s is None:
+        self._p_deactivate()
+
+
+CMFCatalogAware.reindexObjectSecurity = ftw_solr_CatalogAware_reindexObjectSecurity  # noqa
+CatalogMultiplex.reindexObjectSecurity = ftw_solr_CatalogMultiplex_reindexObjectSecurity  # noqa

--- a/ftw/solr/testing.py
+++ b/ftw/solr/testing.py
@@ -1,10 +1,13 @@
 # -*- coding: utf-8 -*-
+from ftw.testing.layer import COMPONENT_REGISTRY_ISOLATION
 from plone.app.testing import applyProfile
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import IntegrationTesting
 from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PloneSandboxLayer
+from plone.testing import z2
 
+import collective.indexing
 import ftw.solr
 
 
@@ -24,12 +27,32 @@ class FtwSolrLayer(PloneSandboxLayer):
         applyProfile(portal, 'ftw.solr:default')
 
 
+class FtwSolrCollectiveIndexingLayer(FtwSolrLayer):
+    """Testing layer that loads collective.indexing's catalog patches in
+    order to test behavior / functionality that depends on the integration
+    via collective.indexing.
+    """
+
+    def setUpZope(self, app, configurationContext):
+        self.loadZCML(package=collective.indexing)
+        z2.installProduct(app, 'collective.indexing')
+
+        self.loadZCML(package=ftw.solr)
+        z2.installProduct(app, 'ftw.solr')
+
+
 FTW_SOLR_FIXTURE = FtwSolrLayer()
+FTW_SOLR_COLLECTIVE_INDEXING_FIXTURE = FtwSolrCollectiveIndexingLayer()
 
 
 FTW_SOLR_INTEGRATION_TESTING = IntegrationTesting(
     bases=(FTW_SOLR_FIXTURE,),
     name='FtwSolrLayer:IntegrationTesting'
+)
+
+FTW_SOLR_COLLECTIVE_INDEXING_INTEGRATION_TESTING = IntegrationTesting(
+    bases=(FTW_SOLR_COLLECTIVE_INDEXING_FIXTURE, COMPONENT_REGISTRY_ISOLATION),
+    name='FtwSolrLayer:CollectiveIndexingIntegrationTesting'
 )
 
 

--- a/ftw/solr/tests/test_collective_indexing_integration.py
+++ b/ftw/solr/tests/test_collective_indexing_integration.py
@@ -1,0 +1,136 @@
+# -*- coding: utf-8 -*-
+from collective.indexing.queue import getQueue
+from datetime import datetime
+from ftw.solr.connection import SolrResponse
+from ftw.solr.interfaces import ISolrConnectionManager
+from ftw.solr.interfaces import ISolrIndexQueueProcessor
+from ftw.solr.schema import SolrSchema
+from ftw.solr.testing import FTW_SOLR_COLLECTIVE_INDEXING_INTEGRATION_TESTING
+from ftw.solr.tests.utils import get_data
+from ftw.testing import freeze
+from mock import call
+from mock import MagicMock
+from mock import PropertyMock
+from plone import api
+from plone.app.testing import login
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from plone.app.testing import TEST_USER_NAME
+from plone.uuid.interfaces import IUUID
+from zope.component import getUtility
+from zope.interface import alsoProvides
+import unittest
+
+
+class TestCollectiveIndexingIntegration(unittest.TestCase):
+
+    layer = FTW_SOLR_COLLECTIVE_INDEXING_INTEGRATION_TESTING
+
+    def setUp(self):
+        super(TestCollectiveIndexingIntegration, self).setUp()
+        self.portal = self.layer['portal']
+        login(self.portal, TEST_USER_NAME)
+        setRoles(self.portal, TEST_USER_ID, ['Manager'])
+
+        # Prepare nested folders so 'View' isn't mapped to the 'Reader' role.
+        self.folder = api.content.create(
+            type='Folder', title='My Folder',
+            id='folder', container=self.portal)
+        self.folder.manage_permission('View', roles=['Other'], acquire=False)
+
+        self.subfolder = api.content.create(
+            type='Folder', title='My Subfolder',
+            id='subfolder', container=self.folder)
+        self.subfolder.manage_permission('View', roles=['Other'], acquire=True)
+
+        self.folder.reindexObjectSecurity()
+        self.subfolder.reindexObjectSecurity()
+
+        # Flush queue to avoid having the above objects getting indexed at
+        # the end of the transaction, after we already installed the mocks
+        getQueue().process()
+
+        self.manager = MagicMock(name='SolrConnectionManager')
+        alsoProvides(self.manager, ISolrConnectionManager)
+
+        conn = MagicMock(name='SolrConnection')
+        conn.get = MagicMock(name='get', return_value=SolrResponse(
+            body=get_data('schema.json'), status=200))
+        type(self.manager).connection = PropertyMock(return_value=conn)
+        type(self.manager).schema = PropertyMock(
+            return_value=SolrSchema(self.manager))
+
+        sm = self.portal.getSiteManager()
+        sm.registerUtility(self.manager, ISolrConnectionManager)
+
+        self.connection = self.manager.connection
+
+        # Manager is memoized on the ISolrIndexQueueProcessor - reset it
+        queue_processor = getUtility(ISolrIndexQueueProcessor, name='ftw.solr')
+        queue_processor._manager = None
+
+    def test_reindex_object_causes_full_reindex_in_solr(self):
+        with freeze(datetime(2018, 8, 31, 13, 45)):
+            self.subfolder.reindexObject()
+        getQueue().process()
+
+        self.connection.add.assert_called_once_with({
+            u'UID': IUUID(self.subfolder),
+            u'Title': u'My Subfolder',
+            u'modified': u'2018-08-31T11:45:00.000Z',
+            u'SearchableText': 'subfolder  My Subfolder ',
+            u'allowedRolesAndUsers': ['Other'],
+            u'path': u'/plone/folder/subfolder',
+        })
+
+    def test_reindex_object_with_idxs_causes_atomic_update(self):
+        self.subfolder.reindexObject(idxs=['Title'])
+        getQueue().process()
+
+        self.connection.add.assert_called_once_with({
+            u'UID': IUUID(self.subfolder),
+            u'Title': {'set': u'My Subfolder'},
+        })
+
+    def test_reindex_object_security_causes_atomic_update(self):
+        # Subfolder previously hasn't had 'View' mapped to any roles.
+        # Explicitly give it to 'Reader' role.
+        self.subfolder.manage_permission(
+            'View', roles=['Reader'], acquire=False)
+
+        self.subfolder.reindexObjectSecurity()
+        getQueue().process()
+
+        self.connection.add.assert_called_once_with({
+            u'UID': IUUID(self.subfolder),
+            u'allowedRolesAndUsers': {'set': [u'Reader']},
+        })
+
+    def test_reindex_object_security_is_recursive(self):
+        # Both folder and subfolder haven't previously had 'View' mapped to
+        # any roles. Subfolder has 'View' set to acquire though. Giving it
+        # to 'Reader' on Folder should therefore propagate down to Subfolder.
+        self.folder.manage_permission('View', roles=['Reader'], acquire=False)
+
+        self.folder.reindexObjectSecurity()
+        getQueue().process()
+
+        expected_calls = [
+            call({
+                'allowedRolesAndUsers': {'set': [u'Reader']},
+                u'UID': IUUID(self.folder)}),
+            call({
+                'allowedRolesAndUsers': {'set': [u'Other', u'Reader']},
+                u'UID': IUUID(self.subfolder)})
+        ]
+        self.assertEqual(2, len(self.connection.add.mock_calls))
+        # XXX: Why isn't call order stable here?
+        self.connection.add.assert_has_calls(expected_calls, any_order=True)
+
+    def test_reindex_object_security_honors_skip_self(self):
+        self.subfolder.manage_permission('View', roles=['Reader'], acquire=False)
+
+        self.subfolder.reindexObjectSecurity(skip_self=True)
+        getQueue().process()
+
+        self.assertEqual(0, len(self.connection.add.mock_calls))

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ tests_require = [
     'plone.api',
     'pytz',
     'mock',
+    'ftw.testing',
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ tests_require = [
 
 setup(
     name='ftw.solr',
-    version='2.2.1.dev0',
+    version='2.3.0.dev0',
     description="Solr integration for Plone",
     long_description=long_description,
     # Get more from https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
This re-applies the [patch we originally had](https://github.com/4teamwork/ftw.solr/blob/1.10.0/ftw/solr/patches/reindex.py#L57-L90) in the `ftw.solr 1.x` line.

This patch optimizes `CatalogAware.reindexObjectSecurity()` so that it performs substantially better for large trees of objects. The optimization relies on the fact that when recursively reindexing security for a subtree, recursion can safely be terminated as soon as an object is encountered that didn't experience a change to the contents of its indexed security.

Without this patch, and
- `collective.solr == 2.0` the `allowedRolesAndUsers` index won't be properly updated
- `collective.solr == 2.1` the `allowedRolesAndUsers` index will be updated, but in a very inefficient way

With this patch, irrespective of the version of `collective.solr`,
- `allowedRolesAndUsers` will be properly updated in an efficient fashion

---
 
#### Reasoning why terminating recursion early is safe
*(copied from the respective docstring)*

> `CMFCatalogAware.reindexObjectSecurity()` needs to be recursive because changes to an object's security may affect contained subobjects.
>
> Indexed security for objects in Plone can only be influenced by their parents via some kind of **inheritance**. There's exactly two inheritance mechanisms in play:
>
> - Acquisition of permissions via the obj's security settings (manage_access)
> - Inheritance of local roles
>
> *(An obj's security settings can indirectly be managed via workflows. This doesn't matter here though, it's irrelevant how exactly they came to be).*
>
> In both of these cases, only the **immediate** parent of a subobject is relevant for inheritance. Therefore, if an object's indexed security didn't experience any changes, neither can any of its subobjects - recursively.
>
> Because of this, downstream propagation can be stopped as soon as an object is encountered whose indexed security didn't change.
>
> ---
>
> In the case of workflow changes, reindexObjectSecurity() still needs to be called for every object that is *directly* affected by the change:
>
> - switched to a different WF
> - to a different WF state
> - changes in the WF state's security settings
> - object moved to/out of a placeful WF).
>
> Identifying these objects is usually easy, and you can't and must not rely on reinexObjectSecurity's recursion to pick them up. Instead, they can be determined by querying for the relevant criteria, e.g. objects that have a particular WF.
>
> Recursion will then take care of updating security indexes for affected subobjects that *don't* meet the criteria for being directly affected (like subobjects with a different workflow).

See 4teamwork/opengever.core#4759 for some more background.
