### PR TITLE
Fix partial reindexing (atomic updates) for fields without a value.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 2.3.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix partial reindexing (atomic updates) for fields without a value.
+  [buchi]
 
 
 2.3.1 (2018-11-01)

--- a/ftw/solr/handlers.py
+++ b/ftw/solr/handlers.py
@@ -50,6 +50,8 @@ class DefaultIndexHandler(object):
         if attributes:
             id_ = data[unique_key]
             data = {k: {'set': v} for k, v in data.items() if k != unique_key}
+            if not data:
+                return
             data[unique_key] = id_
 
         conn.add(data)

--- a/ftw/solr/tests/test_handlers.py
+++ b/ftw/solr/tests/test_handlers.py
@@ -97,6 +97,11 @@ class TestDefaultIndexHandler(unittest.TestCase):
             u'path': {'set': u'/plone/doc'},
         })
 
+    def test_add_with_attributes_without_data_does_nothing(self):
+        self.manager.connection.add = MagicMock(name='add')
+        self.handler.add(['Description'])
+        self.assertFalse(self.manager.connection.add.called)
+
     def test_delete(self):
         self.manager.connection.delete = MagicMock(name='delete')
         self.handler.delete()


### PR DESCRIPTION
Do not add documents without any values at all.
Adding a document without values would result in clearing it.