### PR TITLE
Near Real Time Searching

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,10 @@ Changelog
   time (NRT) searching.
   [buchi]
 
+- Additionaly index metadata of files using an update command to make them
+  visible as soon as possible.
+  [buchi]
+
 
 2.3.2 (2019-04-29)
 ------------------

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,9 @@ Changelog
 2.3.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Perform soft commits and wait for new searcher by default to allow near real
+  time (NRT) searching.
+  [buchi]
 
 
 2.3.2 (2019-04-29)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -12,6 +12,9 @@ Changelog
   visible as soon as possible.
   [buchi]
 
+- Flush optimize command.
+  [buchi]
+
 
 2.3.2 (2019-04-29)
 ------------------

--- a/ftw/solr/browser/maintenance.py
+++ b/ftw/solr/browser/maintenance.py
@@ -66,7 +66,7 @@ class SolrMaintenanceView(BrowserView):
         """Clear all data from Solr index."""
         conn = self.manager.connection
         conn.delete_by_query('*:*')
-        conn.commit()
+        conn.commit(soft_commit=False)
         return 'Solr index cleared.'
 
     def reindex(self, commit_interval=100, idxs=None, doom=True):
@@ -84,7 +84,7 @@ class SolrMaintenanceView(BrowserView):
 
         def commit():
             conn = self.manager.connection
-            conn.commit(extract_after_commit=False)
+            conn.commit(soft_commit=False, extract_after_commit=False)
             zodb_conn.cacheGC()
             self.log(
                 'Intermediate commit (%d items processed, last batch in %s)',
@@ -142,7 +142,7 @@ class SolrMaintenanceView(BrowserView):
 
         def commit():
             conn = self.manager.connection
-            conn.commit(extract_after_commit=False)
+            conn.commit(soft_commit=False, extract_after_commit=False)
             zodb_conn.cacheGC()
             self.log(
                 'Intermediate commit (%d items processed, last batch in %s)',
@@ -226,7 +226,7 @@ class SolrMaintenanceView(BrowserView):
 
         def commit():
             conn = self.manager.connection
-            conn.commit(extract_after_commit=False)
+            conn.commit(soft_commit=False, extract_after_commit=False)
             zodb_conn.cacheGC()
             self.log(
                 'Intermediate commit (%d items processed, last batch in %s)',
@@ -249,7 +249,7 @@ class SolrMaintenanceView(BrowserView):
         conn = self.manager.connection
         for uid in not_in_catalog:
             conn.delete(uid)
-        conn.commit()
+        conn.commit(soft_commit=False)
 
         self.log('Solr index synced.')
         self.log(

--- a/ftw/solr/connection.py
+++ b/ftw/solr/connection.py
@@ -89,12 +89,14 @@ class SolrConnection(object):
         self.update_commands.append(
             '"delete": ' + json.dumps({'query': query}))
 
-    def commit(self, wait_searcher=False, extract_after_commit=True):
+    def commit(self, wait_searcher=True, soft_commit=True,
+               extract_after_commit=True):
         self.update_commands.append(
-            '"commit": ' + json.dumps({'waitSearcher': wait_searcher}))
+            '"commit": ' + json.dumps(
+                {'waitSearcher': wait_searcher, 'softCommit': soft_commit}))
         self.flush(extract_after_commit=extract_after_commit)
 
-    def optimize(self, wait_searcher=False):
+    def optimize(self, wait_searcher=True):
         self.update_commands.append(
             '"optimize": ' + json.dumps({'waitSearcher': wait_searcher}))
 

--- a/ftw/solr/connection.py
+++ b/ftw/solr/connection.py
@@ -79,6 +79,7 @@ class SolrConnection(object):
 
     def extract(self, blob, data):
         """Add blob using Solr's Extracting Request Handler."""
+        self.update_commands.append('"add": ' + json.dumps({'doc': data}))
         self.extract_commands.append((blob, data))
 
     def delete(self, id_):

--- a/ftw/solr/connection.py
+++ b/ftw/solr/connection.py
@@ -100,6 +100,7 @@ class SolrConnection(object):
     def optimize(self, wait_searcher=True):
         self.update_commands.append(
             '"optimize": ' + json.dumps({'waitSearcher': wait_searcher}))
+        self.flush()
 
     def flush(self, extract_after_commit=True):
         """Send queued update commands to Solr."""

--- a/ftw/solr/tests/test_connection.py
+++ b/ftw/solr/tests/test_connection.py
@@ -79,13 +79,14 @@ class TestConnection(unittest.TestCase):
         conn.commit()
         conn.flush.assert_called_once_with(extract_after_commit=True)
         self.assertEqual(
-            conn.update_commands, ['"commit": {"waitSearcher": false}'])
+            conn.update_commands,
+            ['"commit": {"softCommit": true, "waitSearcher": true}'])
 
     def test_optimize_operation_queues_update_command(self):
         conn = SolrConnection(base='/solr/mycore')
         conn.optimize()
         self.assertEqual(
-            conn.update_commands, ['"optimize": {"waitSearcher": false}'])
+            conn.update_commands, ['"optimize": {"waitSearcher": true}'])
 
     def test_flush_operation_posts_update_commands_and_clears_queue(self):
         conn = SolrConnection(base='/solr/mycore')

--- a/ftw/solr/tests/test_connection.py
+++ b/ftw/solr/tests/test_connection.py
@@ -105,7 +105,12 @@ class TestConnection(unittest.TestCase):
         conn.extract(MockBlob(), {'id': '1'})
         conn.flush()
         tr.commit()
-        conn.post.assert_called_once_with(
+        args, kwargs = conn.post.call_args_list[0]
+        self.assertEqual(args, ('/update',))
+        self.assertEqual(
+            kwargs,
+            {'data': '{"add": {"doc": {"id": "1"}}}', 'log_error': False})
+        conn.post.assert_called_with(
             '/update/extract?literal.id=1&commitWithin=10000'
             '&stream.file=%2Ffolder%2Ffile',
             headers={'Content-Type': 'application/x-www-form-urlencoded'},
@@ -117,7 +122,12 @@ class TestConnection(unittest.TestCase):
         conn.post = MagicMock(name='post')
         conn.extract(MockBlob(), {'id': '1'})
         conn.flush(extract_after_commit=False)
-        conn.post.assert_called_once_with(
+        args, kwargs = conn.post.call_args_list[0]
+        self.assertEqual(args, ('/update',))
+        self.assertEqual(
+            kwargs,
+            {'data': '{"add": {"doc": {"id": "1"}}}', 'log_error': False})
+        conn.post.assert_called_with(
             '/update/extract?literal.id=1&commitWithin=10000'
             '&stream.file=%2Ffolder%2Ffile',
             headers={'Content-Type': 'application/x-www-form-urlencoded'},

--- a/ftw/solr/tests/test_connection.py
+++ b/ftw/solr/tests/test_connection.py
@@ -82,9 +82,11 @@ class TestConnection(unittest.TestCase):
             conn.update_commands,
             ['"commit": {"softCommit": true, "waitSearcher": true}'])
 
-    def test_optimize_operation_queues_update_command(self):
+    def test_optimize_operation_queues_update_command_and_flushes_queue(self):
         conn = SolrConnection(base='/solr/mycore')
+        conn.flush = MagicMock(name='flush')
         conn.optimize()
+        conn.flush.assert_called_once()
         self.assertEqual(
             conn.update_commands, ['"optimize": {"waitSearcher": true}'])
 


### PR DESCRIPTION
Perform soft commit on update.
This make documents available for search almost immediately after being indexed.
However changes are not yet saved to disk. Thus regular hard commits must be ensured by enabling autocommit.

The metadata of files is now indexed the same way as other content types to make them visible as soon as possible. They get indexed again using the extracting request handler which also indexes the blob data. This means that file metadata gets indexed twice because the extracting request handler does not support atomic updates.
 