### PR TITLE
Handle facet_counts in solr response

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 2.4.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Handle facet_counts in solr response.
+  [njohner]
 
 
 2.4.0 (2019-06-13)

--- a/ftw/solr/connection.py
+++ b/ftw/solr/connection.py
@@ -1,3 +1,4 @@
+from ftw.solr.helpers import group_by_two
 from ftw.solr.interfaces import ISolrConnectionConfig
 from ftw.solr.interfaces import ISolrConnectionManager
 from ftw.solr.schema import SolrSchema
@@ -201,6 +202,7 @@ class SolrResponse(object):
         self.qtime = 0
         self.params = None
         self.docs = []
+        self.facets = {}
         self.num_found = 0
         self.start = 0
         self.body = {}
@@ -228,6 +230,12 @@ class SolrResponse(object):
             self.num_found = data[u'response'].get(u'numFound', 0)
             self.start = data[u'response'].get(u'start', 0)
 
+        if u'facet_counts' in data:
+            facet_fields = data[u'facet_counts'].get(u'facet_fields', {})
+            for field, counts in facet_fields.items():
+                # facet counts are arranged in a tuple with the form
+                # (facet1, count1, facet2, count2, ...)
+                self.facets[field] = dict(group_by_two(counts))
         self.body = data
 
     def is_ok(self):

--- a/ftw/solr/helpers.py
+++ b/ftw/solr/helpers.py
@@ -1,0 +1,7 @@
+from itertools import izip
+
+
+def group_by_two(iterable):
+    # group_by_two('ABCDEFG') --> AB CD EF
+    args = [iter(iterable)] * 2
+    return izip(*args)

--- a/ftw/solr/tests/data/search_with_facets.json
+++ b/ftw/solr/tests/data/search_with_facets.json
@@ -1,0 +1,99 @@
+{
+  "responseHeader": {
+    "status": 0,
+    "QTime": 3,
+    "params": {
+      "json": "{\n  \"query\": \":\"\n}"
+    }
+  },
+  "response": {
+    "numFound": 3,
+    "start": 0,
+    "docs": [
+      {
+        "UID": "85bed8c49f6d4f8b841693c6a7c6cff1",
+        "Title": "My Folder 1",
+        "SearchableText": "my-folder-1 My Folder 1",
+        "path_parent": "/my-folder-1",
+        "Description": "",
+        "path": "/my-folder-1",
+        "_version_": 1588410098478219264,
+        "created": "2017-12-31T10:47:28.448Z",
+        "modified": "2018-01-01T16:35:46.262Z",
+        "id": "my-folder-1",
+        "portal_type": "Folder",
+        "allowedRolesAndUsers": [
+          "Contributor",
+          "Editor",
+          "Manager",
+          "Reader",
+          "Site Administrator",
+          "_View_Permission",
+          "user:admin"
+        ],
+        "review_state": "private"
+      },
+      {
+        "UID": "85a29144758f494c88df19182f749ed6",
+        "Title": "My Folder 2",
+        "SearchableText": "my-folder-2 My Folder 2",
+        "path_parent": "/my-folder-2",
+        "Description": "",
+        "path": "/my-folder-2",
+        "_version_": 1588410098511773696,
+        "created": "2017-12-31T10:14:46.855Z",
+        "modified": "2017-12-31T13:32:55.328Z",
+        "id": "my-folder-2",
+        "portal_type": "Folder",
+        "allowedRolesAndUsers": [
+          "Contributor",
+          "Editor",
+          "Manager",
+          "Reader",
+          "Site Administrator",
+          "_View_Permission",
+          "user:admin"
+        ],
+        "review_state": "private"
+      },
+      {
+        "UID": "9398dad21bcd49f8a197cd50d10ea778",
+        "Title": "My Document",
+        "SearchableText": "my-document My Document",
+        "path_parent": "/my-folder-1/my-document",
+        "Description": "",
+        "path": "/my-folder-1/my-document",
+        "_version_": 1588410098528550912,
+        "created": "2017-12-31T11:17:00.009Z",
+        "modified": "2017-12-31T11:17:00.137Z",
+        "id": "my-document",
+        "portal_type": "Document",
+        "allowedRolesAndUsers": [
+          "Contributor",
+          "Editor",
+          "Manager",
+          "Reader",
+          "Site Administrator",
+          "_View_Permission",
+          "user:admin"
+        ],
+        "review_state": "private"
+      }
+    ]
+  },
+  "facet_counts": {
+    "facet_queries": {},
+    "facet_fields": {
+      "portal_type": [
+        "Document", 1,
+        "Folder", 2
+        ],
+      "review_state": [
+        "private", 3
+        ]
+      },
+    "facet_ranges": {},
+    "facet_intervals": {},
+    "facet_heatmaps": {}
+  }
+}

--- a/ftw/solr/tests/test_response.py
+++ b/ftw/solr/tests/test_response.py
@@ -32,6 +32,20 @@ class TestResponse(unittest.TestCase):
         self.assertEqual(len(resp.docs), 3)
         self.assertEqual(resp.num_found, 3)
         self.assertEqual(resp.start, 0)
+        self.assertEqual(len(resp.facets), 0)
+        self.assertEqual(resp.facets, {})
+
+    def test_response_from_search_request_with_facets(self):
+        body = get_data('search_with_facets.json')
+        resp = SolrResponse(body=body, status=200)
+        self.assertTrue(resp.is_ok())
+        self.assertEqual(len(resp.docs), 3)
+        self.assertEqual(resp.num_found, 3)
+        self.assertEqual(resp.start, 0)
+        self.assertEqual(len(resp.facets), 2)
+        self.assertEqual(resp.facets,
+                         {u'portal_type': {u'Folder': 2, u'Document': 1},
+                          u'review_state': {u'private': 3}})
 
     def test_response_from_search_with_highlighting(self):
         body = get_data('highlighting.json')


### PR DESCRIPTION
For the new GEVER UI we need the possibility to optionally query for facet available values on the listing endpoint (https://github.com/4teamwork/opengever.core/issues/5738). In this PR we add parsing of the returned `facet_counts` to the `SolrResponse `.

This can be tested in conjunction with https://github.com/4teamwork/opengever.core/pull/5761
