### PR TITLE
Make sure to always update 'path_depth' if 'path' is (re)indexed.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 2.4.1 (unreleased)
 ------------------
 
+- Make sure to always update 'path_depth' if 'path' is (re)indexed.
+  [lgraf]
+
 - Handle facet_counts in solr response.
   [njohner]
 

--- a/ftw/solr/handlers.py
+++ b/ftw/solr/handlers.py
@@ -97,8 +97,16 @@ class DefaultIndexHandler(object):
             attributes = set(schema.fields.keys())
         else:
             attributes = set(schema.fields.keys()).intersection(attributes)
+
         if schema.unique_key not in attributes:
             attributes.add(schema.unique_key)
+
+        # If path gets (re)indexed, we also need to (re)index path_depth
+        # in Solr. Because path_depth is not a catalog index, we would
+        # otherwise fail to update it in cases where a specific list of
+        # `idxs` including path is passed to reindexObject().
+        if 'path' in attributes:
+            attributes.add('path_depth')
 
         data = {}
         for name in attributes:

--- a/ftw/solr/tests/test_handlers.py
+++ b/ftw/solr/tests/test_handlers.py
@@ -63,9 +63,9 @@ class TestDefaultIndexHandler(unittest.TestCase):
         self.assertEqual(
             {
                 u'UID': u'09baa75b67f44383880a6dab8b3200b6',
-                u'path': u'/plone/doc',
+                u'modified': u'2017-01-21T17:18:19.000Z',
             },
-            self.handler.get_data(['UID', 'path'])
+            self.handler.get_data(['UID', 'modified'])
         )
 
     def test_get_data_always_includes_unique_key(self):
@@ -92,11 +92,11 @@ class TestDefaultIndexHandler(unittest.TestCase):
 
     def test_add_with_attributes_does_atomic_update(self):
         self.manager.connection.add = MagicMock(name='add')
-        self.handler.add(['Title', 'path'])
+        self.handler.add(['Title', 'modified'])
         self.manager.connection.add.assert_called_once_with({
             u'UID': u'09baa75b67f44383880a6dab8b3200b6',
             u'Title': {'set': u'My Document'},
-            u'path': {'set': u'/plone/doc'},
+            u'modified': {'set': u'2017-01-21T17:18:19.000Z'},
         })
 
     def test_add_with_attributes_without_data_does_nothing(self):

--- a/ftw/solr/tests/test_handlers.py
+++ b/ftw/solr/tests/test_handlers.py
@@ -77,6 +77,16 @@ class TestDefaultIndexHandler(unittest.TestCase):
             self.handler.get_data(['Title'])
         )
 
+    def test_get_data_includes_path_depth_if_path_was_included(self):
+        self.assertEqual(
+            {
+                u'path': u'/plone/doc',
+                u'path_depth': 2,
+                u'UID': u'09baa75b67f44383880a6dab8b3200b6',
+            },
+            self.handler.get_data(['path'])
+        )
+
     def test_add_without_attributes_adds_full_documemt(self):
         self.manager.connection.add = MagicMock(name='add')
         self.handler.add(None)

--- a/solr-config/conf/managed-schema
+++ b/solr-config/conf/managed-schema
@@ -111,6 +111,7 @@
     <field name="Title" type="text" indexed="true" stored="true"/>
     <field name="allowedRolesAndUsers" type="string" indexed="true" stored="false" multiValued="true"/>
     <field name="path_parent" type="descendent_path" indexed="true" stored="true" />
+    <field name="path_depth" type="pint" indexed="true" stored="false" />
     <field name="path" type="string" indexed="true" stored="false" />
     <field name="id" type="string" indexed="true" stored="false" />
     <field name="portal_type" type="string" indexed="true" stored="false" />


### PR DESCRIPTION
This is a follow-up to #132 where support for indexing path depth was added.

We need to make sure to always update `path_depth` as well if `path` is (re)indexed:

In some cases, the `path` catalog index will be updated for an object specifically by passing `path` in the list of `idxs` of a `reindexObject()` call. One such case is [moving an object while `ftw.copymovepatches` is installed](https://github.com/4teamwork/ftw.copymovepatches/blob/1bdffdf428e452af851aa29da910d6e2824343af/ftw/copymovepatches/cmfcatalogaware.py#L82-L88).

Because `path_depth` is not a Plone catalog index, it will not be listed in these cases (by Plone or a Plone addon product). It still needs to be updated though in those cases, because it's contents are functionally dependent on the object's path.

We therefore make sure to always add `path_depth` to the list of attributes to be indexed if `path` is already in there (and we're not doing a full reindex).