### PR TITLE
Fix error when trying to delete an object without a unique key

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2.5.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix error when trying to delete an object without a unique key. [jone]
 
 
 2.5.0 (2019-07-02)

--- a/ftw/solr/handlers.py
+++ b/ftw/solr/handlers.py
@@ -80,6 +80,7 @@ class DefaultIndexHandler(object):
             logger.warning(
                 'Object is missing unique key, skipping unindexing of %r',
                 self.context)
+            return
 
         conn.delete(data[unique_key])
 


### PR DESCRIPTION
A `return` statement was missing.