### PR TITLE
Use Solr Cell only for text extraction

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,10 @@ Changelog
 2.5.1 (unreleased)
 ------------------
 
+- Use Solr Cell only for text extraction. The SearchableText is now also indexed
+  using the update handler which allows atomic updates. Also fixes #137.
+  [buchi]
+
 - Fix error when trying to delete an object without a unique key. [jone]
 
 

--- a/ftw/solr/handlers.py
+++ b/ftw/solr/handlers.py
@@ -20,61 +20,40 @@ class DefaultIndexHandler(object):
         self.manager = manager
 
     def add(self, attributes):
-        conn = self.manager.connection
-        if conn is None:
+        if self.manager.connection is None:
             return
 
-        schema = self.manager.schema
-        if not schema:
-            logger.warning(
-                'Unable to fetch schema, skipping indexing of %r',
-                self.context)
-            return
-
-        unique_key = schema.unique_key
-        if unique_key is None:
-            logger.warning(
-                'Schema is missing unique key, skipping indexing of %r',
-                self.context)
+        error = self.get_schema_error()
+        if error:
+            logger.warning('%s, skipping indexing of %r', error, self.context)
             return
 
         data = self.get_data(attributes)
 
+        unique_key = self.manager.schema.unique_key
         if unique_key not in data:
             logger.warning(
                 'Object is missing unique key, skipping indexing of %r',
                 self.context)
             return
 
-        # Atomic update: add set modifier except for unique key
         if attributes:
-            id_ = data[unique_key]
-            data = {k: {'set': v} for k, v in data.items() if k != unique_key}
-            if not data:
-                return
-            data[unique_key] = id_
+            data = self.add_atomic_update_modifier(data, unique_key)
 
-        conn.add(data)
+        if data:
+            self.manager.connection.add(data)
 
     def delete(self):
-        conn = self.manager.connection
-        if conn is None:
+        if self.manager.connection is None:
             return
 
-        schema = self.manager.schema
-        if not schema:
+        error = self.get_schema_error()
+        if error:
             logger.warning(
-                'Unable to fetch schema, skipping unindexing of %r',
-                self.context)
+                '%s, skipping unindexing of %r', error, self.context)
             return
 
-        unique_key = schema.unique_key
-        if unique_key is None:
-            logger.warning(
-                'Schema is missing unique key, skipping unindexing of %r',
-                self.context)
-            return
-
+        unique_key = self.manager.schema.unique_key
         data = self.get_data([unique_key])
         if unique_key not in data:
             logger.warning(
@@ -82,7 +61,7 @@ class DefaultIndexHandler(object):
                 self.context)
             return
 
-        conn.delete(data[unique_key])
+        self.manager.connection.delete(data[unique_key])
 
     def get_data(self, attributes):
         if not IIndexableObject.providedBy(self.context):
@@ -137,65 +116,91 @@ class DefaultIndexHandler(object):
 
         return data
 
+    def get_schema_error(self):
+        if not self.manager.schema:
+            return 'Unable to fetch schema'
+
+        if self.manager.schema.unique_key is None:
+            return 'Schema is missing unique key'
+
+    def add_atomic_update_modifier(self, data, unique_key):
+        id_ = data[unique_key]
+        data = {k: {'set': v} for k, v in data.items() if k != unique_key}
+        if not data:
+            return
+        data[unique_key] = id_
+        return data
+
 
 @implementer(ISolrIndexHandler)
 class ATBlobFileIndexHandler(DefaultIndexHandler):
 
     def add(self, attributes):
-        conn = self.manager.connection
-        if conn is None:
+        if self.manager.connection is None:
             return
 
-        if attributes and 'SearchableText' not in attributes:
-            return super(ATBlobFileIndexHandler, self).add(attributes)
-
-        schema = self.manager.schema
-        if not schema:
-            logger.warning(
-                'Unable to fetch schema, skipping indexing of %r',
-                self.context)
+        error = self.get_schema_error()
+        if error:
+            logger.warning('%s, skipping indexing of %r', error, self.context)
             return
 
         if attributes is None:
-            attributes = schema.fields.keys()
-        attributes.remove('SearchableText')
+            attributes = self.manager.schema.fields.keys()
 
+        extract = False
+        if 'SearchableText' in attributes:
+            attributes.remove('SearchableText')
+            extract = True
+
+        unique_key = self.manager.schema.unique_key
         data = self.get_data(attributes)
-        field = self.context.getPrimaryField()
-        blob = field.get(self.context).blob
 
-        conn.extract(blob, data)
+        if attributes:
+            self.manager.connection.add(
+                self.add_atomic_update_modifier(data, unique_key))
+
+        if extract:
+            field = self.context.getPrimaryField()
+            blob = field.get(self.context).blob
+            self.manager.connection.extract(
+                blob, 'SearchableText', {unique_key: data[unique_key]})
 
 
 @implementer(ISolrIndexHandler)
 class DexterityItemIndexHandler(DefaultIndexHandler):
 
     def add(self, attributes):
-        conn = self.manager.connection
-        if conn is None:
+        if self.manager.connection is None:
             return
 
+        error = self.get_schema_error()
+        if error:
+            logger.warning('%s, skipping indexing of %r', error, self.context)
+            return
+
+        blob = None
         try:
             info = IPrimaryFieldInfo(self.context, None)
         except TypeError:
             info = None
         if info is not None and INamedBlobFile.providedBy(info.value):
             blob = info.value._blob
-        else:
-            return super(DexterityItemIndexHandler, self).add(attributes)
 
-        if attributes and 'SearchableText' not in attributes:
-            return super(DexterityItemIndexHandler, self).add(attributes)
-
-        schema = self.manager.schema
-        if not schema:
-            logger.warning(
-                'Unable to fetch schema, skipping indexing of %r',
-                self.context)
-            return
         if attributes is None:
-            attributes = schema.fields.keys()
-        attributes.remove('SearchableText')
+            attributes = self.manager.schema.fields.keys()
 
+        extract = False
+        if 'SearchableText' in attributes and blob is not None:
+            attributes.remove('SearchableText')
+            extract = True
+
+        unique_key = self.manager.schema.unique_key
         data = self.get_data(attributes)
-        conn.extract(blob, data)
+
+        if attributes:
+            self.manager.connection.add(
+                self.add_atomic_update_modifier(data, unique_key))
+
+        if extract:
+            self.manager.connection.extract(
+                blob, 'SearchableText', {unique_key: data[unique_key]})

--- a/ftw/solr/testing.py
+++ b/ftw/solr/testing.py
@@ -9,6 +9,7 @@ from plone.testing import z2
 
 import collective.indexing
 import ftw.solr
+import plone.app.contenttypes
 
 
 class FtwSolrLayer(PloneSandboxLayer):
@@ -27,6 +28,20 @@ class FtwSolrLayer(PloneSandboxLayer):
         applyProfile(portal, 'ftw.solr:default')
 
 
+class FtwSolrDexterityLayer(PloneSandboxLayer):
+
+    defaultBases = (PLONE_FIXTURE,)
+
+    def setUpZope(self, app, configurationContext):
+        z2.installProduct(app, 'Products.DateRecurringIndex')
+        self.loadZCML(package=plone.app.contenttypes)
+        self.loadZCML(package=ftw.solr)
+
+    def setUpPloneSite(self, portal):
+        applyProfile(portal, 'plone.app.contenttypes:default')
+        applyProfile(portal, 'ftw.solr:default')
+
+
 class FtwSolrCollectiveIndexingLayer(FtwSolrLayer):
     """Testing layer that loads collective.indexing's catalog patches in
     order to test behavior / functionality that depends on the integration
@@ -42,12 +57,18 @@ class FtwSolrCollectiveIndexingLayer(FtwSolrLayer):
 
 
 FTW_SOLR_FIXTURE = FtwSolrLayer()
+FTW_SOLR_DEXTERITY_FIXTURE = FtwSolrDexterityLayer()
 FTW_SOLR_COLLECTIVE_INDEXING_FIXTURE = FtwSolrCollectiveIndexingLayer()
 
 
 FTW_SOLR_INTEGRATION_TESTING = IntegrationTesting(
     bases=(FTW_SOLR_FIXTURE,),
     name='FtwSolrLayer:IntegrationTesting'
+)
+
+FTW_SOLR_DEXTERITY_INTEGRATION_TESTING = IntegrationTesting(
+    bases=(FTW_SOLR_DEXTERITY_FIXTURE,),
+    name='FtwSolrDexterityLayer:IntegrationTesting'
 )
 
 FTW_SOLR_COLLECTIVE_INDEXING_INTEGRATION_TESTING = IntegrationTesting(

--- a/ftw/solr/tests/test_connection.py
+++ b/ftw/solr/tests/test_connection.py
@@ -60,8 +60,8 @@ class TestConnection(unittest.TestCase):
 
     def test_extract_operation_queues_extract_command(self):
         conn = SolrConnection()
-        conn.extract('Blob', {'id': '1'})
-        self.assertEqual(conn.extract_commands, [('Blob', {'id': '1'})])
+        conn.extract('Blob', 'SearchableText', {'id': '1'})
+        self.assertEqual(conn.extract_commands, [('Blob', 'SearchableText', {'id': '1'})])
 
     def test_delete_operation_queues_update_command(self):
         conn = SolrConnection()
@@ -103,52 +103,59 @@ class TestConnection(unittest.TestCase):
     def test_flush_operation_posts_extract_commands_and_clears_queue(self):
         conn = SolrConnection(base='/solr/mycore')
         conn.post = MagicMock(name='post')
+        conn.post.return_value.body.get.return_value = 'The searchable text'
         tr = transaction.begin()
-        conn.extract(MockBlob(), {'id': '1'})
+        conn.extract(MockBlob(), 'SearchableText', {'id': '1'})
         conn.flush()
         tr.commit()
         args, kwargs = conn.post.call_args_list[0]
+        self.assertEqual(
+            args,
+            ('/update/extract?extractOnly=true&stream.file=%2Ffolder%2Ffile',))
+        self.assertEqual(
+            kwargs,
+            {'headers': {'Content-Type': 'application/x-www-form-urlencoded'},
+             'log_error': False},
+        )
+        args, kwargs = conn.post.call_args_list[1]
         self.assertEqual(args, ('/update',))
         self.assertEqual(
             kwargs,
-            {'data': '{"add": {"doc": {"id": "1"}}}', 'log_error': False})
-        conn.post.assert_called_with(
-            '/update/extract?literal.id=1&commitWithin=10000'
-            '&stream.file=%2Ffolder%2Ffile',
-            headers={'Content-Type': 'application/x-www-form-urlencoded'},
-            log_error=False)
+            {'data': '{"add": {"doc": {"id": "1", "SearchableText": {"set": "T'
+                     'he searchable text"}}}}',
+             'log_error': False})
         self.assertEqual(conn.extract_commands, [])
 
     def test_flush_operation_without_after_commit_hook(self):
         conn = SolrConnection(base='/solr/mycore')
         conn.post = MagicMock(name='post')
-        conn.extract(MockBlob(), {'id': '1'})
+        conn.post.return_value.body.get.return_value = 'The searchable text'
+        conn.extract(MockBlob(), 'SearchableText', {'id': '1'})
         conn.flush(extract_after_commit=False)
+
         args, kwargs = conn.post.call_args_list[0]
+        self.assertEqual(
+            args,
+            ('/update/extract?extractOnly=true&stream.file=%2Ffolder%2Ffile',))
+        self.assertEqual(
+            kwargs,
+            {'headers': {'Content-Type': 'application/x-www-form-urlencoded'},
+             'log_error': False},
+        )
+        args, kwargs = conn.post.call_args_list[1]
         self.assertEqual(args, ('/update',))
         self.assertEqual(
             kwargs,
-            {'data': '{"add": {"doc": {"id": "1"}}}', 'log_error': False})
-        conn.post.assert_called_with(
-            '/update/extract?literal.id=1&commitWithin=10000'
-            '&stream.file=%2Ffolder%2Ffile',
-            headers={'Content-Type': 'application/x-www-form-urlencoded'},
-            log_error=False)
-        self.assertEqual(conn.extract_commands, [])
+            {'data': '{"add": {"doc": {"id": "1", "SearchableText": {"set": "T'
+                     'he searchable text"}}}}',
+             'log_error': False})
 
-    def test_extract_with_boolean_query_params(self):
-        conn = SolrConnection(base='/solr/mycore')
-        conn.post = MagicMock(name='post')
-        conn.extract(MockBlob(), {'id': '1', 'b1': True, 'b2': False})
-        conn.flush(extract_after_commit=False)
-        args, kwargs = conn.post.call_args
-        self.assertIn('literal.b1=true', args[0])
-        self.assertIn('literal.b2=false', args[0])
+        self.assertEqual(conn.extract_commands, [])
 
     def test_abort_operation_clears_queue(self):
         conn = SolrConnection(base='/solr/mycore')
         conn.add({'id': '1'})
-        conn.extract(MockBlob(), {'id': '1'})
+        conn.extract(MockBlob(), 'SearchableText', {'id': '1'})
         conn.abort()
         self.assertEqual(conn.update_commands, [])
         self.assertEqual(conn.extract_commands, [])

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ tests_require = [
     'plone.app.dexterity',
     'plone.testing',
     'plone.api',
+    'plone.app.contenttypes',
     'pytz',
     'mock',
     'ftw.testing',


### PR DESCRIPTION
The metadata of files is now indexed the same way as other items.
The SearchableText is first extracted using Solr Cell and then indexed as an
atomic update.

Fixes #137