### PR TITLE
Fix 'path_depth' indexing handling, when its not part of the schema.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2.6.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix 'path_depth' indexing handling, when 'path_depth' is not part of the schema. [phgross]
 
 
 2.6.0 (2019-08-19)

--- a/ftw/solr/handlers.py
+++ b/ftw/solr/handlers.py
@@ -85,7 +85,7 @@ class DefaultIndexHandler(object):
         # in Solr. Because path_depth is not a catalog index, we would
         # otherwise fail to update it in cases where a specific list of
         # `idxs` including path is passed to reindexObject().
-        if 'path' in attributes:
+        if 'path' in attributes and 'path_depth' in schema.fields:
             attributes.add('path_depth')
 
         data = {}

--- a/ftw/solr/tests/test_handlers.py
+++ b/ftw/solr/tests/test_handlers.py
@@ -81,11 +81,21 @@ class TestDefaultIndexHandler(unittest.TestCase):
             self.handler.get_data(['Title'])
         )
 
-    def test_get_data_includes_path_depth_if_path_was_included(self):
+    def test_get_data_includes_path_depth_if_exists_and_path_was_included(self):
         self.assertEqual(
             {
                 u'path': u'/plone/doc',
                 u'path_depth': 2,
+                u'UID': u'09baa75b67f44383880a6dab8b3200b6',
+            },
+            self.handler.get_data(['path'])
+        )
+
+        # solr schemas without the path_depth field
+        self.manager.schema.fields.pop('path_depth')
+        self.assertEqual(
+            {
+                u'path': u'/plone/doc',
                 u'UID': u'09baa75b67f44383880a6dab8b3200b6',
             },
             self.handler.get_data(['path'])


### PR DESCRIPTION
The special handling for the `path_depth` field introduced in #134 only works when the `path_depth` is configured as field in the schema.