### PR TITLE
Avoid sending atomic update commands with null-documents

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2.6.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Avoid sending atomic update commands with null-documents. [lgraf]
 
 
 2.6.1 (2019-08-26)

--- a/ftw/solr/handlers.py
+++ b/ftw/solr/handlers.py
@@ -156,8 +156,9 @@ class ATBlobFileIndexHandler(DefaultIndexHandler):
         data = self.get_data(attributes)
 
         if attributes:
-            self.manager.connection.add(
-                self.add_atomic_update_modifier(data, unique_key))
+            data = self.add_atomic_update_modifier(data, unique_key)
+            if data:
+                self.manager.connection.add(data)
 
         if extract:
             field = self.context.getPrimaryField()
@@ -198,8 +199,9 @@ class DexterityItemIndexHandler(DefaultIndexHandler):
         data = self.get_data(attributes)
 
         if attributes:
-            self.manager.connection.add(
-                self.add_atomic_update_modifier(data, unique_key))
+            data = self.add_atomic_update_modifier(data, unique_key)
+            if data:
+                self.manager.connection.add(data)
 
         if extract:
             self.manager.connection.extract(

--- a/ftw/solr/tests/test_handlers.py
+++ b/ftw/solr/tests/test_handlers.py
@@ -125,7 +125,7 @@ class TestDefaultIndexHandler(unittest.TestCase):
 
     def test_add_with_attributes_without_data_does_nothing(self):
         self.manager.connection.add = MagicMock(name='add')
-        self.handler.add(['Description'])
+        self.handler.add(['field_not_in_schema'])
         self.assertFalse(self.manager.connection.add.called)
 
     def test_delete(self):
@@ -216,6 +216,11 @@ class TestATBlobFileIndexHandler(unittest.TestCase):
             'SearchableText',
             {u'UID': u'09baa75b67f44383880a6dab8b3200b6'},
         )
+
+    def test_add_with_attributes_without_data_does_nothing(self):
+        self.manager.connection.add = MagicMock(name='add')
+        self.handler.add(['field_not_in_schema'])
+        self.assertFalse(self.manager.connection.add.called)
 
 
 class TestDexterityItemIndexHandler(unittest.TestCase):
@@ -334,3 +339,8 @@ class TestDexterityItemIndexHandler(unittest.TestCase):
             u'SearchableText': {'set': ' doc2 My Document   '},
         })
         self.manager.connection.extract.assert_not_called()
+
+    def test_add_with_attributes_without_data_does_nothing(self):
+        self.manager.connection.add = MagicMock(name='add')
+        self.handler.add(['field_not_in_schema'])
+        self.assertFalse(self.manager.connection.add.called)


### PR DESCRIPTION
The `DefaultIndexHandler` handled this correctly, but the `ATBlobFileIndexHandler` and `DexterityItemIndexHandler` didn't.

In cases where `attributes` only consists of index names that don't correspond to a field in the Solr schema, we did end up in a situation where `data` was `None`, and was sent to Solr as
the "document" in an atomic update command:

```
"add": {"doc": null}
```

This would Solr to respond with a `400`, and reject the entire request which could contain other, valid updates.

---

Solr Response in the case of this error:

```json
{  
   "responseHeader":{  
      "status":400,
      "QTime":57
   },
   "error":{  
      "msg":"Expected: OBJECT_START but got NULL at [1968]",
      "code":400,
      "metadata":[  
         "error-class",
         "org.apache.solr.common.SolrException",
         "root-error-class",
         "org.apache.solr.common.SolrException"
      ]
   }
}
```

Corresponding log entry:

```
2019-09-09 16:24:56.850 INFO  (qtp117009527-18) [   x:testserver] o.a.s.u.p.LogUpdateProcessorFactory [testserver]  webapp=/solr path=/update params={}{add=[createcontacts000000000000000001 (1644208163965108224), createcontacts000000000000000001 (1644208164015439872), createcontacts000000000000000001 (1644208164016488448)]} 0 55
2019-09-09 16:24:56.851 ERROR (qtp117009527-18) [   x:testserver] o.a.s.h.RequestHandlerBase org.apache.solr.common.SolrException: Expected: OBJECT_START but got NULL at [1968]
    <traceback>
```