### PR TITLE
Remove filter of or/and/not in searchterm highlighting 1.x

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 1.12.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Remove searchterm highlighter word filter [Nachtalb]
 
 
 1.12.0 (2019-04-23)

--- a/ftw/solr/skins/ftw_solr/jquery.highlightsearchterms.js
+++ b/ftw/solr/skins/ftw_solr/jquery.highlightsearchterms.js
@@ -106,7 +106,7 @@
             var self = this;
             return $.unique($.map(terms, function(term) {
                 term = $.trim(self.caseInsensitive ? term.toLowerCase() : term);
-                return (!term || self.filterTerms.test(term)) ? null : term;
+                return !term ? null : term;
             }));
         },
 
@@ -197,8 +197,6 @@
 
         // Are terms matched case insensitive?
         caseInsensitive: true,
-        // what terms are never to be highlighted (regexp)?
-        filterTerms: /(not|and|or)/i,
         // What class is used to mark highlighted search terms?
         highlightClass: 'highlightedSearchTerm'
     };


### PR DESCRIPTION
This is so that everything can be searched for and be easily found regardless
of what it is. This eg. also filtered out words including and like eg. "hand".