### PR TITLE
Add support for uploading blobs to extract handler.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,6 +58,20 @@ buildout. Example::
             <solr:connection host="localhost" port="8983" base="/solr/mycore"/>
        </configure>
 
+By default, ``ftw.solr`` will do full text extraction by passing the blob's
+filesystem path to the Solr Cell extract handler, assuming that Solr runs on
+the same machine and has access to the blob storage.
+
+For setups where this isn't desired, the connection option ``upload_blobs``
+can be set to ``true`` in order to make ``ftw.solr`` upload the blobs directly
+to the extract handler via HTTP POST:
+
+    [instance]
+    zcml-additional =
+        <configure xmlns:solr="http://namespaces.plone.org/solr">
+            <solr:connection host="localhost" port="8983" base="/solr/mycore" upload_blobs="true"/>
+       </configure>
+
 
 Run buildout
 ------------

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -1,8 +1,11 @@
 Changelog
 =========
 
-2.7.1 (unreleased)
+2.8.0 (unreleased)
 ------------------
+
+- Add support for uploading blobs to extract handler.
+  [lgraf]
 
 - Add support for Plone 5.0 and 5.1.
   [buchi]

--- a/ftw/solr/handlers.py
+++ b/ftw/solr/handlers.py
@@ -163,8 +163,10 @@ class ATBlobFileIndexHandler(DefaultIndexHandler):
         if extract:
             field = self.context.getPrimaryField()
             blob = field.get(self.context).blob
+            content_type = field.get(self.context).getContentType()
             self.manager.connection.extract(
-                blob, 'SearchableText', {unique_key: data[unique_key]})
+                blob, 'SearchableText', {unique_key: data[unique_key]},
+                content_type)
 
 
 @implementer(ISolrIndexHandler)
@@ -180,12 +182,14 @@ class DexterityItemIndexHandler(DefaultIndexHandler):
             return
 
         blob = None
+        content_type = None
         try:
             info = IPrimaryFieldInfo(self.context, None)
         except TypeError:
             info = None
         if info is not None and INamedBlobFile.providedBy(info.value):
             blob = info.value._blob
+            content_type = info.value.contentType
 
         if attributes is None:
             attributes = self.manager.schema.fields.keys()
@@ -205,4 +209,5 @@ class DexterityItemIndexHandler(DefaultIndexHandler):
 
         if extract:
             self.manager.connection.extract(
-                blob, 'SearchableText', {unique_key: data[unique_key]})
+                blob, 'SearchableText', {unique_key: data[unique_key]},
+                content_type)

--- a/ftw/solr/helpers.py
+++ b/ftw/solr/helpers.py
@@ -1,7 +1,27 @@
+from functools import partial
 from itertools import izip
+
+
+MAXCHUNKSIZE = 1 << 16
 
 
 def group_by_two(iterable):
     # group_by_two('ABCDEFG') --> AB CD EF
     args = [iter(iterable)] * 2
     return izip(*args)
+
+
+def chunked_file_reader(open_file, chunk_size=MAXCHUNKSIZE):
+    for chunk in iter(partial(open_file.read, chunk_size), ''):
+        yield chunk
+
+
+def http_chunked_encoder(iterable):
+    for data in iterable:
+        chunk_size = '%s\r\n' % hex(len(data))[2:]
+        chunk_data = '%s\r\n' % data
+        chunk = chunk_size + chunk_data
+        yield chunk
+
+    # last chunk
+    yield '0\r\n\r\n'

--- a/ftw/solr/tests/test_handlers.py
+++ b/ftw/solr/tests/test_handlers.py
@@ -158,6 +158,11 @@ class TestATBlobFileIndexHandler(unittest.TestCase):
         self.doc = api.content.create(
             type='File', title='My File', id='doc',
             file='File data ...', container=self.portal)
+
+        field = self.doc.getPrimaryField().get(self.doc)
+        field.setFilename('document.docx')
+        field.setContentType('application/vnd.openxmlformats-officedocument.wordprocessingml.document')
+
         if base_hasattr(self.doc, '_setUID'):
             self.doc._setUID('09baa75b67f44383880a6dab8b3200b6')
             self.doc.setModificationDate(DateTime('2017-01-21T17:18:19+00:00'))
@@ -190,6 +195,7 @@ class TestATBlobFileIndexHandler(unittest.TestCase):
             self.doc.getFile().blob,
             'SearchableText',
             {u'UID': u'09baa75b67f44383880a6dab8b3200b6'},
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
         )
 
     def test_add_with_attributes_without_searchabletext_calls_add(self):
@@ -215,6 +221,7 @@ class TestATBlobFileIndexHandler(unittest.TestCase):
             self.doc.getFile().blob,
             'SearchableText',
             {u'UID': u'09baa75b67f44383880a6dab8b3200b6'},
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
         )
 
     def test_add_with_searchabletext_only_calls_extract(self):
@@ -226,6 +233,7 @@ class TestATBlobFileIndexHandler(unittest.TestCase):
             self.doc.getFile().blob,
             'SearchableText',
             {u'UID': u'09baa75b67f44383880a6dab8b3200b6'},
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
         )
 
     def test_add_with_attributes_without_data_does_nothing(self):
@@ -246,7 +254,7 @@ class TestDexterityItemIndexHandler(unittest.TestCase):
         namedfile = NamedBlobFile(
             data='File data ...',
             filename=u'document.docx',
-            contentType='application/vnd.openxmlformats-officedocument. wordprocessingml.document')
+            contentType='application/vnd.openxmlformats-officedocument.wordprocessingml.document')
         self.doc = api.content.create(
             type='File', title='My File', id='doc',
             file=namedfile, container=self.portal)
@@ -283,6 +291,7 @@ class TestDexterityItemIndexHandler(unittest.TestCase):
             self.doc.file._blob,
             'SearchableText',
             {u'UID': u'09baa75b67f44383880a6dab8b3200b6'},
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
         )
 
     def test_add_with_attributes_without_searchabletext_calls_add(self):
@@ -304,6 +313,7 @@ class TestDexterityItemIndexHandler(unittest.TestCase):
             self.doc.file._blob,
             'SearchableText',
             {u'UID': u'09baa75b67f44383880a6dab8b3200b6'},
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
         )
 
     def test_add_with_searchabletext_only_calls_extract(self):
@@ -313,6 +323,7 @@ class TestDexterityItemIndexHandler(unittest.TestCase):
             self.doc.file._blob,
             'SearchableText',
             {u'UID': u'09baa75b67f44383880a6dab8b3200b6'},
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
         )
 
     def test_add_without_attributes_for_item_without_blob_calls_add(self):

--- a/ftw/solr/tests/test_helpers.py
+++ b/ftw/solr/tests/test_helpers.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from ftw.solr.helpers import chunked_file_reader
+from ftw.solr.helpers import http_chunked_encoder
+from StringIO import StringIO
+import unittest
+
+
+class TestHelpers(unittest.TestCase):
+
+    def test_chunked_file_reader(self):
+        fileobj = StringIO("Lorem Ipsum")
+        reader = chunked_file_reader(fileobj, chunk_size=3)
+        self.assertEqual(['Lor', 'em ', 'Ips', 'um'], list(reader))
+
+    def test_http_chunked_encoder(self):
+        encoder = http_chunked_encoder(['Lorem', 'Ipsum.'])
+        self.assertEqual(
+            ['5\r\nLorem\r\n', '6\r\nIpsum.\r\n', '0\r\n\r\n'],
+            list(encoder))

--- a/ftw/solr/zcml.py
+++ b/ftw/solr/zcml.py
@@ -28,9 +28,16 @@ class ISolrConnectionConfigDirective(Interface):
         required=True,
     )
 
+    upload_blobs = schema.Bool(
+        title=u"Upload Blobs",
+        description=u"Upload blobs to extract handler via HTTP POST instead "
+                    u"of making Solr retrieve them via filesystem.",
+        default=False,
+    )
 
-def solr_connection_config_directive(_context, host, port, base):
+
+def solr_connection_config_directive(_context, host, port, base, upload_blobs):
 
     utility(_context,
             provides=ISolrConnectionConfig,
-            component=SolrConnectionConfig(host, port, base))
+            component=SolrConnectionConfig(host, port, base, upload_blobs))

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ tests_require = [
 
 setup(
     name='ftw.solr',
-    version='2.7.1.dev0',
+    version='2.8.0.dev0',
     description="Solr integration for Plone",
     long_description=long_description,
     # Get more from https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
Add support for uploading blobs to Solr Cells `extract` handler via HTTP POST (instead of passing it a file path that causes the extract handler retrieve the blob from the blob storage on the filesystem).

This introduces a new connection configuration option `upload_blobs` (default: `False`). If set, `ftw.solr` will upload the blob's content with the HTTP POST request made to the `extract` handler. This allows setups where Solr doesn't run on the same machine where the blob storage is located.

File upload is performed in a streaming fashion with HTTP/1.1 chunked transfer to avoid loading the entire blob into memory.

This is part of 4teamwork/opengever.core#6023.