### PR TITLE
Limit max width for search overlay.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 1.13.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Add max width for search result overlay on desktop computers. [busykoala]
 
 
 1.13.1 (2019-10-21)

--- a/ftw/solr/browser/resources/livesearch.scss
+++ b/ftw/solr/browser/resources/livesearch.scss
@@ -10,6 +10,7 @@
       right: -$line-height-base !important;
       left: auto !important;
       top: ($line-height-base + 3 * $padding-vertical) !important;
+      max-width: 80vw;
 
       &:after, &:before {
         visibility: visible !important;


### PR DESCRIPTION
Close https://github.com/4teamwork/demo.intranet/issues/3

When a contents description was too long the search results overlay grew out of the page.
With this change we limit it to 80% of the viewport for desktop computers while it stays 100% for mobile devices as before.

The search overlay is not growing out of the page anymore if there is a long description.

![image](https://user-images.githubusercontent.com/29920936/69795000-9a1f5780-11cb-11ea-8f9d-8caa15040698.png)

For mobile devices nothing changed.

![image](https://user-images.githubusercontent.com/29920936/69795049-b8855300-11cb-11ea-9093-631a7b76030d.png)
