### PR TITLE
Fix livesearch for while user is on contentish object

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 -------------------
 
 - Add max width for search result overlay on desktop computers. [busykoala]
+- Fix livesearch on contentish [Nachtalb]
 
 
 1.13.1 (2019-10-21)

--- a/ftw/solr/browser/configure.zcml
+++ b/ftw/solr/browser/configure.zcml
@@ -13,6 +13,16 @@
         allowed_attributes="facet_parameters"
         layer="ftw.solr.interfaces.IFtwSolrLayer" />
 
+    <!-- We use this in livesearch and so it must also be available for items as context -->
+    <browser:page
+        for="OFS.interfaces.IItem"
+        name="search-facets"
+        template="facets.pt"
+        class=".facets.SearchFacetsView"
+        permission="zope2.View"
+        allowed_attributes="facet_parameters"
+        layer="ftw.solr.interfaces.IFtwSolrLayer" />
+
     <browser:page
         for="OFS.interfaces.IFolder"
         name="available-facets"


### PR DESCRIPTION
The livesearch accesses "search-facets" on the current context and when
the user was on a contentish object (like the detail view of an
ftw.addressblock.Addressblock or the fron-page created on the default
plone installation) the livesearch view threw an error because
"search-facets" was not available for that object.