### PR TITLE
Fix to_iso8601 for years before 1900.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 2.8.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix to_iso8601 for years before 1900.
+  [deiferni]
 
 
 2.8.0 (2019-12-06)

--- a/ftw/solr/converters.py
+++ b/ftw/solr/converters.py
@@ -13,12 +13,15 @@ def to_iso8601(value, multivalued=False):
         if value.tzinfo is not None:
             # Convert to timezone naive in UTC
             value = (value - value.utcoffset()).replace(tzinfo=None)
-        value = u'%s.%03dZ' % (
-            value.strftime('%Y-%m-%dT%H:%M:%S'),
-            value.microsecond / 1000
+
+        value = u'%04d-%02d-%02dT%02d:%02d:%02d.%03dZ' % (
+            value.year, value.month, value.day, value.hour, value.minute,
+            value.second, value.microsecond / 1000
         )
     elif isinstance(value, date):
-        value = value.strftime('%Y-%m-%dT%H:%M:%S.000Z').decode()
+        value = u'%04d-%02d-%02dT%02d:%02d:%02d.%03dZ' % (
+            value.year, value.month, value.day, 0, 0, 0, 0
+        )
     else:
         value = None
     return value

--- a/ftw/solr/tests/test_converters.py
+++ b/ftw/solr/tests/test_converters.py
@@ -32,10 +32,40 @@ class TestDateTimeConverter(unittest.TestCase):
         self.assertIsInstance(dt, unicode)
         self.assertEqual(dt, u'2017-10-21T14:28:16.936Z')
 
+    def test_datetime_before_1900_converts_to_iso8601(self):
+        dt = to_iso8601(datetime(1871, 3, 30, 1, 2))
+        self.assertIsInstance(dt, unicode)
+        self.assertEqual(dt, u'1871-03-30T01:02:00.000Z')
+
+    def test_datetime_before_1000_converts_to_iso8601(self):
+        dt = to_iso8601(datetime(971, 3, 30, 17))
+        self.assertIsInstance(dt, unicode)
+        self.assertEqual(dt, u'0971-03-30T17:00:00.000Z')
+
+    def test_datetime_before_100_converts_to_iso8601(self):
+        dt = to_iso8601(datetime(71, 3, 30))
+        self.assertIsInstance(dt, unicode)
+        self.assertEqual(dt, u'0071-03-30T00:00:00.000Z')
+
     def test_python_date_converts_to_iso8601(self):
         dt = to_iso8601(date(2017, 10, 21))
         self.assertIsInstance(dt, unicode)
         self.assertEqual(dt, u'2017-10-21T00:00:00.000Z')
+
+    def test_date_before_1900_converts_to_iso8601(self):
+        dt = to_iso8601(date(1871, 3, 30))
+        self.assertIsInstance(dt, unicode)
+        self.assertEqual(dt, u'1871-03-30T00:00:00.000Z')
+
+    def test_date_before_1000_converts_to_iso8601(self):
+        dt = to_iso8601(date(971, 3, 30))
+        self.assertIsInstance(dt, unicode)
+        self.assertEqual(dt, u'0971-03-30T00:00:00.000Z')
+
+    def test_date_before_100_converts_to_iso8601(self):
+        dt = to_iso8601(date(71, 3, 30))
+        self.assertIsInstance(dt, unicode)
+        self.assertEqual(dt, u'0071-03-30T00:00:00.000Z')
 
     def test_invalid_date_converts_to_none(self):
         self.assertEqual(to_iso8601('30'), None)


### PR DESCRIPTION
Implement formatting to support years before 1900 for `date` and `datetime` instances.

Python 2.7 can't handle that yet as per https://docs.python.org/2/library/datetime.html#strftime-strptime-behavior.

I tried various approaches but ended up implementing the formatting myself as has already been done for `DateTime` instances. To prevent any issues with solr i'd like to keep the output stable and avoid changing the string representation of dates too much, especially since this is intended as a bugfix level release. Switching to `isoformat` or the `arrow` library would all have significantly changed the iso8601 string.