### PR TITLE
Fix check for no attributes

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2.8.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix blob extraction for DX items. [mbaechtold]
 
 
 2.8.1 (2020-02-05)

--- a/ftw/solr/handlers.py
+++ b/ftw/solr/handlers.py
@@ -191,7 +191,7 @@ class DexterityItemIndexHandler(DefaultIndexHandler):
             blob = info.value._blob
             content_type = info.value.contentType
 
-        if attributes is None:
+        if not attributes:
             attributes = self.manager.schema.fields.keys()
 
         extract = False

--- a/ftw/solr/tests/test_handlers.py
+++ b/ftw/solr/tests/test_handlers.py
@@ -294,6 +294,23 @@ class TestDexterityItemIndexHandler(unittest.TestCase):
             'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
         )
 
+    def test_add_with_empty_list_attributes_calls_add_and_extract(self):
+        self.handler.add([])
+        self.manager.connection.add.assert_called_once_with({
+            u'UID': u'09baa75b67f44383880a6dab8b3200b6',
+            u'Title': {u'set': u'My File'},
+            u'modified': {u'set': u'2017-01-21T17:18:19.000Z'},
+            u'allowedRolesAndUsers': {u'set': [u'Anonymous']},
+            u'path': {u'set': u'/plone/doc'},
+            u'path_depth': {u'set': 2},
+        })
+        self.manager.connection.extract.assert_called_once_with(
+            self.doc.file._blob,
+            'SearchableText',
+            {u'UID': u'09baa75b67f44383880a6dab8b3200b6'},
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+        )
+
     def test_add_with_attributes_without_searchabletext_calls_add(self):
         self.handler.add(['Title', 'modified'])
         self.manager.connection.add.assert_called_once_with({


### PR DESCRIPTION
Newer Plone versions provide an empty list of indexes while previous version provided `None`.

This commit contains the same changes as the commit https://github.com/4teamwork/ftw.solr/pull/147/commits/e7f58e50d4771594d5cc3a32062279a94c95ea83, but for the DX handler this time.