### PR TITLE
Fix rounding errors with DateTime milliseconds.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2.8.2 (unreleased)
 ------------------
 
+- Fix to_iso8601 prevent rounding errors with DateTime milliseconds above 999500. [deiferni]
 - Fix blob extraction for DX items. [mbaechtold]
 
 

--- a/ftw/solr/converters.py
+++ b/ftw/solr/converters.py
@@ -1,13 +1,16 @@
 from DateTime import DateTime
 from datetime import datetime
 from datetime import date
+import math
 
 
 def to_iso8601(value, multivalued=False):
     if isinstance(value, DateTime):
         v = value.toZone('UTC')
-        value = u'%04d-%02d-%02dT%02d:%02d:%06.3fZ' % (
-            v.year(), v.month(), v.day(), v.hour(), v.minute(), v.second()
+        millisecond, second = math.modf(v.second())
+        value = u'%04d-%02d-%02dT%02d:%02d:%02d.%03dZ' % (
+            v.year(), v.month(), v.day(), v.hour(), v.minute(),
+            int(second), millisecond * 1000
         )
     elif isinstance(value, datetime):
         if value.tzinfo is not None:

--- a/ftw/solr/tests/test_converters.py
+++ b/ftw/solr/tests/test_converters.py
@@ -72,24 +72,28 @@ class TestDateTimeConverter(unittest.TestCase):
         self.assertEqual(to_iso8601(30), None)
 
     def test_zope_datetime_high_millis_does_not_cause_rounding_error_low(self):
-        dt = to_iso8601(DateTime('2017-10-21 16:28:16.999501'))
+        dt = to_iso8601(DateTime('2017-10-21 16:28:59.999501'))
         self.assertIsInstance(dt, unicode)
-        self.assertEqual(dt, u'2017-10-21T16:28:16.999Z')
+        self.assertNotEqual(dt, u'2017-10-21T16:28:60.000Z')
+        self.assertEqual(dt, u'2017-10-21T16:28:59.999Z')
 
     def test_zope_datetime_high_millis_does_not_cause_rounding_error_high(self):
-        dt = to_iso8601(DateTime('2017-10-21 16:28:16.999999'))
+        dt = to_iso8601(DateTime('2017-10-21 16:28:59.999999'))
         self.assertIsInstance(dt, unicode)
-        self.assertEqual(dt, u'2017-10-21T16:28:16.999Z')
+        self.assertNotEqual(dt, u'2017-10-21T16:28:60.000Z')
+        self.assertEqual(dt, u'2017-10-21T16:28:59.999Z')
 
     def test_datetime_high_millis_does_not_cause_rounding_error_low(self):
-        dt = to_iso8601(datetime(2017, 10, 21, 16, 28, 16, 999501))
+        dt = to_iso8601(datetime(2017, 10, 21, 16, 28, 59, 999501))
         self.assertIsInstance(dt, unicode)
-        self.assertEqual(dt, u'2017-10-21T16:28:16.999Z')
+        self.assertNotEqual(dt, u'2017-10-21T16:28:60.000Z')
+        self.assertEqual(dt, u'2017-10-21T16:28:59.999Z')
 
     def test_datetime_high_millis_does_not_cause_rounding_error_high(self):
-        dt = to_iso8601(datetime(2017, 10, 21, 16, 28, 16, 999999))
+        dt = to_iso8601(datetime(2017, 10, 21, 16, 28, 59, 999999))
         self.assertIsInstance(dt, unicode)
-        self.assertEqual(dt, u'2017-10-21T16:28:16.999Z')
+        self.assertNotEqual(dt, u'2017-10-21T16:28:60.000Z')
+        self.assertEqual(dt, u'2017-10-21T16:28:59.999Z')
 
 
 class TestStringConverter(unittest.TestCase):

--- a/ftw/solr/tests/test_converters.py
+++ b/ftw/solr/tests/test_converters.py
@@ -71,6 +71,26 @@ class TestDateTimeConverter(unittest.TestCase):
         self.assertEqual(to_iso8601('30'), None)
         self.assertEqual(to_iso8601(30), None)
 
+    def test_zope_datetime_high_millis_does_not_cause_rounding_error_low(self):
+        dt = to_iso8601(DateTime('2017-10-21 16:28:16.999501'))
+        self.assertIsInstance(dt, unicode)
+        self.assertEqual(dt, u'2017-10-21T16:28:16.999Z')
+
+    def test_zope_datetime_high_millis_does_not_cause_rounding_error_high(self):
+        dt = to_iso8601(DateTime('2017-10-21 16:28:16.999999'))
+        self.assertIsInstance(dt, unicode)
+        self.assertEqual(dt, u'2017-10-21T16:28:16.999Z')
+
+    def test_datetime_high_millis_does_not_cause_rounding_error_low(self):
+        dt = to_iso8601(datetime(2017, 10, 21, 16, 28, 16, 999501))
+        self.assertIsInstance(dt, unicode)
+        self.assertEqual(dt, u'2017-10-21T16:28:16.999Z')
+
+    def test_datetime_high_millis_does_not_cause_rounding_error_high(self):
+        dt = to_iso8601(datetime(2017, 10, 21, 16, 28, 16, 999999))
+        self.assertIsInstance(dt, unicode)
+        self.assertEqual(dt, u'2017-10-21T16:28:16.999Z')
+
 
 class TestStringConverter(unittest.TestCase):
 


### PR DESCRIPTION
When milliseconds of a `DateTime` are above 999500 python string formatting rounds up the value. This leads to an ISO 8601 date format strings with a value of 60 for the [ss] (second ) part. Solr considers such date format strings invalid and throws an error, e.g.:

```
Invalid Date in Date Math String:'2015-04-07T14:43:60.000Z'
```

This will result in the corresponding object not being indexed or updated in solr by `ftw.solr`.

With this PR we fix the issue by splitting the `seconds` part of a `DateTime` into separate seconds and milliseconds parts and also pass them as separate arguments to string formatting.

additionally i've reproduced the timestamp issue locally. i have verified that with this fix the solr error no longer pops up and `bin/instance solr sync` is successful and manages to update all objects in solr.