### PR TITLE
Make sure maintenance scripts are run as system user.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2.8.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Make sure maintenance scripts are run as system user. [njohner]
 
 
 2.8.4 (2020-04-02)

--- a/ftw/solr/commands.py
+++ b/ftw/solr/commands.py
@@ -34,7 +34,7 @@ def setup_site(app, options):
 def get_plone_sites(root):
     result = []
     for obj in root.values():
-        if obj.meta_type is 'Folder':
+        if obj.meta_type == 'Folder':
             result = result + get_plone_sites(obj)
         elif IPloneSiteRoot.providedBy(obj):
             result.append(obj)

--- a/ftw/solr/commands.py
+++ b/ftw/solr/commands.py
@@ -1,4 +1,5 @@
 from AccessControl.SecurityManagement import newSecurityManager
+from AccessControl.SpecialUsers import system as system_user
 from Products.CMFPlone.interfaces import IPloneSiteRoot
 from Testing.makerequest import makerequest
 from zope.component import queryMultiAdapter
@@ -23,7 +24,7 @@ def setup_site(app, options):
     if not portal:
         sys.exit("Plone site not found at %s" % options.plone_site)
 
-    user = portal.getOwner()
+    user = system_user.__of__(app.acl_users)
     newSecurityManager(app, user)
 
     setSite(portal)


### PR DESCRIPTION
In the maintenance scripts we rely on the owner of the plone site to be a system. It seems that we have many deployments for which the plone site owner is `admin`, a user that does not exist, and the maintenance scripts therefore get executed as anonymous with obvious consequences, i.e. they fail as not all objects can be accessed.

The proposed fix comes from how this is done for `bin/instance run` scripts (https://github.com/plone/plone.recipe.zope2instance/blob/master/src/plone/recipe/zope2instance/ctl.py#L691-L694).

As to why certain of our sites are owned by the `admin` user, here is what I found out:
- Before creating the plone site, the standard plone `admin; admin` user is available as system user, and you can login with that user to setup the plone site. I think the `acl-users` then gets replaced during installation and that user is not available anymore.
- I could be that some older deployments are pre-`ftw.zopemaster` and that things worked differently at that time?
- Correct way of installing a new deployment would be to zauth on the plone root before installing the plone site.

For https://4teamwork.atlassian.net/browse/GEVER-192