### PR TITLE
Truncate solr maintenance logging. Add max_diff option to limit nof diffed objects.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2.8.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add option to limit items logged in diff, switch default to only diff 5 items. [deiferni]
 
 
 2.8.5 (2020-05-06)

--- a/ftw/solr/commands.py
+++ b/ftw/solr/commands.py
@@ -55,9 +55,16 @@ def solr(app, args):
                         help='Interval for intermediate commits')
     parser.add_argument('-i', '--indexes', nargs='*',
                         help='Perform command on the given indexes')
+    parser.add_argument('--max-diff', dest='max_diff', default=5, type=int,
+                        help="Maximum items to log in diff. Use negative "
+                             "number for infinite.")
     options = parser.parse_args(args[2:])
     app = makerequest(app)
     site = setup_site(app, options)
+
+    max_diff = options.max_diff
+    if max_diff < 0:
+        max_diff = None
 
     solr_maintenance = queryMultiAdapter(
         (site, site.REQUEST), name=u'solr-maintenance')
@@ -69,7 +76,8 @@ def solr(app, args):
             commit_interval=options.commit_interval, idxs=options.indexes)
     elif options.command == 'sync':
         solr_maintenance.sync(
-            commit_interval=options.commit_interval, idxs=options.indexes)
+            commit_interval=options.commit_interval, idxs=options.indexes,
+            max_diff=max_diff)
     elif options.command == 'optimize':
         solr_maintenance.optimize()
         print("Solr index optimized.")
@@ -77,6 +85,6 @@ def solr(app, args):
         solr_maintenance.clear()
         print("Solr index cleared.")
     elif options.command == 'diff':
-        solr_maintenance.diff()
+        solr_maintenance.diff(max_diff=max_diff)
     else:
         sys.exit("Unknown command '%s'." % options.command)

--- a/ftw/solr/tests/test_maintenance.py
+++ b/ftw/solr/tests/test_maintenance.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from ftw.solr.browser.maintenance import ellipsified_join
+import unittest
+
+
+class TestEllipsifiedJoin(unittest.TestCase):
+
+    def test_max_equal_to_item_length(self):
+        self.assertEqual(
+            'eins, zwo',
+            ellipsified_join(['eins', 'zwo'], 2)
+        )
+
+    def test_max_smaller_than_item_length(self):
+        self.assertEqual(
+            'eins, ...',
+            ellipsified_join(['eins', 'zwo'], 1)
+        )
+
+    def test_max_none(self):
+        self.assertEqual(
+            'eins, zwo, drei',
+            ellipsified_join(['eins', 'zwo', 'drei'], None)
+        )


### PR DESCRIPTION
Wit this PR we add an optional max_diff argument to the solr maintenance view and to `bin/instance solr` command line script for the `diff` and `sync` commands. We change the default behavior of verbosely logging all UIDs that are not in sync to only logging the first five by default. Instead we now also log the total number of items not in sync in each category.

The amount of items to log can be adjusted via command line and it is still possible to log all UIDs should one wish to do so. The change is motivated by the fact that in practice we are usually more interested in just the number of items not in sync and the very verbose logging impedes our ability to easily read the script output.

By default only five UIDs are logged in `diff`:
```
$ bin/instance solr diff
2020-05-27 11:41:00 Portal Catalog contains 25407 items.
2020-05-27 11:41:00 Solr contains 25875 items.
2020-05-27 11:41:00 Total of 468 items not in Portal Catalog: 908284b47e1e4484a07337deedb4fd5b, e638c993e1454c42849eafc0da0b3cdf, f4ab24f562664c57b1c285fddc63df6c, 2967c8245afe419a9684c1b414260bc2, 00906520a20c472294697d243173bbe2, ...
2020-05-27 11:41:00 Total of 2 items not in sync: 7e24d9286fcc4b09a25d2ce9d3781dc1, 7656a1b51b2348db8fcda13031f69bb7
```

One can specify the amount of UIDs to log, one could also use numbers < 0 to log all of them.
```
$ bin/instance solr diff --max-diff=7
2020-05-27 11:41:00 Portal Catalog contains 25407 items.
2020-05-27 11:41:00 Solr contains 25875 items.
2020-05-27 11:41:00 Total of 468 items not in Portal Catalog: 908284b47e1e4484a07337deedb4fd5b, e638c993e1454c42849eafc0da0b3cdf, f4ab24f562664c57b1c285fddc63df6c, 2967c8245afe419a9684c1b414260bc2, 00906520a20c472294697d243173bbe2, b70eb473adfa44358e86eb213a4ae129, 924176f10de74711926d9b9d4cb53324, ...
2020-05-27 11:41:00 Total of 2 items not in sync: 7e24d9286fcc4b09a25d2ce9d3781dc1, 7656a1b51b2348db8fcda13031f69bb7
```

Same option als applies to `sync`:
```
ae35:opengever.core deif$ bin/instance solr sync --max-diff=2
2020-05-27 11:43:18 Portal Catalog contains 25407 items.
2020-05-27 11:43:18 Solr contains 25875 items.
2020-05-27 11:43:18 Total of 468 items not in Portal Catalog: 908284b47e1e4484a07337deedb4fd5b, e638c993e1454c42849eafc0da0b3cdf, ...
2020-05-27 11:43:18 Total of 2 items not in sync: 7e24d9286fcc4b09a25d2ce9d3781dc1, 7656a1b51b2348db8fcda13031f69bb7
2020-05-27 11:43:18 Syncing Solr...
2020-05-27 11:43:20 Intermediate commit (2 items processed, last batch in 1.630s)
2020-05-27 11:43:20 Solr index synced.
2020-05-27 11:43:20 Processed 2 items in 1.709s (0.457s cpu time).
```

https://4teamwork.atlassian.net/browse/GEVER-181