### PR TITLE
Log maintenance commands to a dedicated logfile.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2.8.6 (unreleased)
 ------------------
 
+- Log maintenance commands to a dedicated logfile. [lgraf]
 - Add option to limit items logged in diff, switch default to only diff 5 items. [deiferni]
 - Add helper for creating Solr filters from catalog queries.
   [buchi]


### PR DESCRIPTION
This change adds a `TimedRotatingFileHandler` to the already existing `ftw.solr.maintenance` logger, so that **maintenance commands get logged to a dedicated logfile**.

As discussed with @buchi and @deiferni, the log directory is determined by deriving it from the location of Zope's EventLog.

I decided to use a single logfile, `solr-maintenance.log`, for all processes (instances), even though this in theory could lead to concurrency issues because multiple processes might be writing to the same file.

However, I deemed this risk acceptable because
- Maintenance commands will never (intentionally) be executed in parallel. So unlike the event log, this is not a file that's actively being written to most of the time.
- There should not be a risk of actually losing log data (lines). The worst that could happen is hard-to-read interleaving of complete lines, from what I can tell from this article:
  - [Appending to a File from Multiple Processes](https://nullprogram.com/blog/2016/08/03/)
  - POSIX systems guarantee that appends to files opened in `O_APPEND` mode are safely appended (don't truncate other writes)
  - No interleaving should happen on Linux for writes up to 4kB
- The clutter caused by `solr-maintenance-instance1.log`, `solr-maintenance-instance2.log`, ... files IMHO far outweighs this risk.

Jira: https://4teamwork.atlassian.net/browse/GEVER-179
