### PR TITLE
Treat docs with no `created` field as out of sync in solr `diff` and `sync`. 

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2.8.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Treat docs with no created field as out of sync in `diff`. [deiferni]
 
 
 2.8.6 (2020-06-02)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-2.8.7 (unreleased)
+2.9.0 (unreleased)
 ------------------
 
 - Treat docs with no created field as out of sync in `diff`. [deiferni]

--- a/ftw/solr/browser/maintenance.py
+++ b/ftw/solr/browser/maintenance.py
@@ -271,7 +271,14 @@ class SolrMaintenanceView(BrowserView):
                 ellipsified_join(not_in_solr, max_diff))
         if not not_in_catalog and not not_in_solr:
             self.log('Solr and Portal Catalog contain the same items. :-)')
+
         not_in_sync = [item[0] for item in catalog_modified - solr_modified]
+        incomplete = conn.search({
+            u'query': u'-created:[* TO *]',
+            u'limit': 10000000,
+            u'params': {u'fl': 'UID'},
+        })
+        not_in_sync.extend([doc['UID'] for doc in incomplete.docs])
         if not_in_sync:
             self.log(
                 'Total of %s items not in sync: %s',

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ tests_require = [
 
 setup(
     name='ftw.solr',
-    version='2.8.7.dev0',
+    version='2.9.0.dev0',
     description="Solr integration for Plone",
     long_description=long_description,
     # Get more from https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
Solr documents where the `created` field value is missing will now be treated as out of sync with portal catalog. This fixes an issue we had in production where documents that were only inserted partially in solr would not be picked up by `diff` as their `modified` field was provided correctly.

We assume the partial documents were created as following:
- the user created content in plone and queued an add which would fail in rare cases before the fix in https://github.com/4teamwork/ftw.solr/pull/158
- thus a document would not have been added to solr
- during an upgrade or other reindex operation we have queued an atomic update for the plone content which only updated a subset of the fields, e.g. by sending the following update command to solr
```
"add": {"doc": {"path": {"set": "/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-14"}, "UID": "createtreatydossiers000000000002", "path_depth": {"set": 6}, "modified": {"set": "2016-08-31T14:07:33.000Z"}}}
```
- this solr document will have the same `UID` and the same `modified` date as plones portal_catalog, but is missing a lot of essential attributes. it would not be picked up in a solr `diff` however as we only compare `modified` and `UID` for performance reasons
- code-sample for path to failure in: https://github.com/4teamwork/opengever.core/commit/a60b4adfcccf13a690a0264cc9aba710d1d0a911#diff-389a707fb8bf568041230a4812feae10R56-R59

The field `created` can be used as a good heuristic as it is most likely only added via the initial add when an object in plone is created, or only present when all object indices are reindexed without restricting the list of indices. Furthermore the created field should always be present and always be filled with a valid date. It is not changed during the lifetime of plone content under normal circumstances, thus we expect it is never part of an atomic update. 

So if `created` is missing from a document something has gone wrong and that document needs reindexing.

Some basic smoke-tests for this change are provided in https://github.com/4teamwork/opengever.core/pull/6577. This seemed to be the fastest path to some tests as in `ftw.solr` we don't test against a real solr and the maintenance view seems fairly untested 🤔.

For https://4teamwork.atlassian.net/browse/GEVER-795.