### PR TITLE
Cleanup extract_commands before sending them to solr.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2.9.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Cleanup extract_commands before sending them to solr. [njohner]
 
 
 2.9.0 (2020-08-04)

--- a/ftw/solr/tests/utils.py
+++ b/ftw/solr/tests/utils.py
@@ -21,5 +21,8 @@ class MockHTTPResponse(object):
 
 
 class MockBlob(object):
+    def __init__(self, path='/folder/file'):
+        self.path = path
+
     def committed(self):
-        return '/folder/file'
+        return self.path


### PR DESCRIPTION
This fixes an issue where SearchableText for a given document gets extracted several times from different blobs in one transaction. This is inefficient and causes problems because older extract_commands try to extract from blobs that have been overwritten in the meantime, having uncommitted changes which will lead to errors and the document not getting indexed at all. Instead we now filter the list of extract_commands to only keep the relevant ones.

For https://4teamwork.atlassian.net/browse/CA-1104