### PR TITLE
Fix setting document_type back to None

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2.9.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Do not ignore None values when indexing data in solr. [njohner]
 
 
 2.9.1 (2020-12-15)

--- a/ftw/solr/handlers.py
+++ b/ftw/solr/handlers.py
@@ -104,8 +104,6 @@ class DefaultIndexHandler(object):
                 except (AttributeError, TypeError):
                     continue
 
-            if value is None:
-                continue
             field_class = schema.field_types[
                 schema.fields[name][u'type']][u'class']
             multivalued = schema.fields[name].get(u'multiValued', False)


### PR DESCRIPTION
We were skipping attributes with a value of `None` when indexing data in solr. This prevents setting an attribute back to `None`. I don't think this was necessary for anything, at least I did not find any information as to why we were skipping these attributes.

Proof that the fix works in Gever: https://github.com/4teamwork/opengever.core/pull/6809

For https://4teamwork.atlassian.net/browse/CA-1336