### PR TITLE
Fix indexing of SearchableText only for objects with primary field.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,8 +4,7 @@ Changelog
 2.9.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Fix indexing of SearchableText only for objects with primary field. [njohner]
 
 2.9.2 (2021-01-13)
 ------------------

--- a/ftw/solr/handlers.py
+++ b/ftw/solr/handlers.py
@@ -154,10 +154,10 @@ class ATBlobFileIndexHandler(DefaultIndexHandler):
             extract = True
 
         unique_key = self.manager.schema.unique_key
-        data = self.get_data(attributes)
+        raw_data = self.get_data(attributes)
 
         if attributes:
-            data = self.add_atomic_update_modifier(data, unique_key)
+            data = self.add_atomic_update_modifier(raw_data, unique_key)
             if data:
                 self.manager.connection.add(data)
 
@@ -166,7 +166,7 @@ class ATBlobFileIndexHandler(DefaultIndexHandler):
             blob = field.get(self.context).blob
             content_type = field.get(self.context).getContentType()
             self.manager.connection.extract(
-                blob, 'SearchableText', {unique_key: data[unique_key]},
+                blob, 'SearchableText', {unique_key: raw_data[unique_key]},
                 content_type)
 
 
@@ -204,14 +204,14 @@ class DexterityItemIndexHandler(DefaultIndexHandler):
             extract = True
 
         unique_key = self.manager.schema.unique_key
-        data = self.get_data(attributes)
+        raw_data = self.get_data(attributes)
 
         if attributes:
-            data = self.add_atomic_update_modifier(data, unique_key)
+            data = self.add_atomic_update_modifier(raw_data, unique_key)
             if data:
                 self.manager.connection.add(data)
 
         if extract:
             self.manager.connection.extract(
-                blob, 'SearchableText', {unique_key: data[unique_key]},
+                blob, 'SearchableText', {unique_key: raw_data[unique_key]},
                 content_type)

--- a/ftw/solr/handlers.py
+++ b/ftw/solr/handlers.py
@@ -137,6 +137,9 @@ class ATBlobFileIndexHandler(DefaultIndexHandler):
         if self.manager.connection is None:
             return
 
+        if isinstance(attributes, tuple):
+            attributes = list(attributes)
+
         error = self.get_schema_error()
         if error:
             logger.warning('%s, skipping indexing of %r', error, self.context)
@@ -173,6 +176,9 @@ class DexterityItemIndexHandler(DefaultIndexHandler):
     def add(self, attributes):
         if self.manager.connection is None:
             return
+
+        if isinstance(attributes, tuple):
+            attributes = list(attributes)
 
         error = self.get_schema_error()
         if error:

--- a/ftw/solr/tests/test_handlers.py
+++ b/ftw/solr/tests/test_handlers.py
@@ -257,6 +257,19 @@ class TestATBlobFileIndexHandler(unittest.TestCase):
             'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
         )
 
+    def test_add_with_only_searchable_text_and_uid_calls_extract(self):
+        self.manager.connection.add = MagicMock(name='add')
+        self.manager.connection.extract = MagicMock(name='extract')
+
+        self.handler.add(('SearchableText', 'UID'))
+        self.manager.connection.add.assert_not_called()
+        self.manager.connection.extract.assert_called_once_with(
+            self.doc.getFile().blob,
+            'SearchableText',
+            {u'UID': u'09baa75b67f44383880a6dab8b3200b6'},
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+        )
+
 
 class TestDexterityItemIndexHandler(unittest.TestCase):
 
@@ -406,6 +419,16 @@ class TestDexterityItemIndexHandler(unittest.TestCase):
             u'UID': u'09baa75b67f44383880a6dab8b3200b6',
             u'modified': {'set': u'2017-01-21T17:18:19.000Z'},
         })
+        self.manager.connection.extract.assert_called_once_with(
+            self.doc.file._blob,
+            'SearchableText',
+            {u'UID': u'09baa75b67f44383880a6dab8b3200b6'},
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+        )
+
+    def test_add_with_only_searchable_text_and_uid_calls_extract(self):
+        self.handler.add(('SearchableText', 'UID'))
+        self.manager.connection.add.assert_not_called()
         self.manager.connection.extract.assert_called_once_with(
             self.doc.file._blob,
             'SearchableText',

--- a/ftw/solr/tests/test_handlers.py
+++ b/ftw/solr/tests/test_handlers.py
@@ -241,6 +241,22 @@ class TestATBlobFileIndexHandler(unittest.TestCase):
         self.handler.add(['field_not_in_schema'])
         self.assertFalse(self.manager.connection.add.called)
 
+    def test_add_with_attributes_as_tuple_with_searchabletext(self):
+        self.manager.connection.add = MagicMock(name='add')
+        self.manager.connection.extract = MagicMock(name='extract')
+
+        self.handler.add(('SearchableText', 'modified'))
+        self.manager.connection.add.assert_called_once_with({
+            u'UID': u'09baa75b67f44383880a6dab8b3200b6',
+            u'modified': {'set': u'2017-01-21T17:18:19.000Z'},
+        })
+        self.manager.connection.extract.assert_called_once_with(
+            self.doc.getFile().blob,
+            'SearchableText',
+            {u'UID': u'09baa75b67f44383880a6dab8b3200b6'},
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+        )
+
 
 class TestDexterityItemIndexHandler(unittest.TestCase):
 
@@ -383,3 +399,16 @@ class TestDexterityItemIndexHandler(unittest.TestCase):
         self.manager.connection.add = MagicMock(name='add')
         self.handler.add(['field_not_in_schema'])
         self.assertFalse(self.manager.connection.add.called)
+
+    def test_add_with_attributes_as_tuple_with_searchabletext(self):
+        self.handler.add(('SearchableText', 'modified'))
+        self.manager.connection.add.assert_called_once_with({
+            u'UID': u'09baa75b67f44383880a6dab8b3200b6',
+            u'modified': {'set': u'2017-01-21T17:18:19.000Z'},
+        })
+        self.manager.connection.extract.assert_called_once_with(
+            self.doc.file._blob,
+            'SearchableText',
+            {u'UID': u'09baa75b67f44383880a6dab8b3200b6'},
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+        )


### PR DESCRIPTION
Two problems surfaced that hinder reindexing only `SearchableText` and `UID` in opengever.core. `UID` is of course used only to avoid reindexing everything in Gever catalog, so we really only want to reindex the `SearchableText` in solr. When indexes are specified, `collective.indexing` will actually pass the `attributes` as a tuple. The handler in `ftw.solr`, tries to remove `SearchableText` from that tuple, which fails.

Moreover the `add_atomic_update_modifier` will return `None` whenever the `attributes` list contains only the `unique_key`, i.e. `UID` in our case. In such cases, the call of the `extract` method would fail, because
it tries to retrieve the `unique_key` from that empty dictionary.

For https://4teamwork.atlassian.net/browse/CA-1361