### PR TITLE
Make solr search result page more robust agains random querystrings

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 1.13.8 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix render issues if we get a random query string. [mathias.leimgruber]
 
 
 1.13.7 (2021-02-26)

--- a/ftw/solr/browser/search.py
+++ b/ftw/solr/browser/search.py
@@ -232,7 +232,11 @@ class SearchView(SEARCH_VIEW):
 
         # Path may be a list, but wie deal only with the first item anyway
         path = isinstance(path, list) and path[0] or path
-        item = self.context.unrestrictedTraverse(path)
+        try:
+            item = self.context.unrestrictedTraverse(path)
+        except KeyError:
+            # Path doesn't exist
+            return None
         del query_dict['path']
 
         return {'search_url': '{0}?{1}'.format(self.request.get('ACTUAL_URL'),

--- a/ftw/solr/browser/selected-facets.pt
+++ b/ftw/solr/browser/selected-facets.pt
@@ -1,5 +1,5 @@
 <div tal:omit-tag=""
-     tal:define="facets view/facets; selected view/selected"
+     tal:define="facets view/facets | nothing; selected view/selected | nothing"
      tal:condition="python: selected"
      i18n:domain="solr">
 


### PR DESCRIPTION
This PR solves two common issues according to our sentry entries:
- path param with a random value -> catch KeyError while traversing a random path.
- random value for facets -> Needs to contain a `:`, the rendering facets failed if it did not.
