### PR TITLE
Add an unrestricted search method to SolrSearch.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2.9.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add unrestricted_search method. [njohner]
 
 
 2.9.4 (2021-07-29)

--- a/ftw/solr/search.py
+++ b/ftw/solr/search.py
@@ -20,8 +20,8 @@ class SolrSearch(object):
             self._manager = queryUtility(ISolrConnectionManager)
         return self._manager
 
-    def search(self, request_handler=u'/select', query=u'*:*', filters=None,
-               start=0, rows=1000, sort=None, **params):
+    def _search(self, request_handler=u'/select', query=u'*:*', filters=None,
+                start=0, rows=1000, sort=None, unrestricted=False, **params):
         conn = self.manager.connection
         params = {u'params': params}
         params[u'query'] = query
@@ -33,9 +33,22 @@ class SolrSearch(object):
             filters = []
         if not isinstance(filters, list):
             filters = [filters]
-        filters.insert(0, self.security_filter())
+        if not unrestricted:
+            filters.insert(0, self.security_filter())
         params[u'filter'] = filters
         return conn.search(params, request_handler=request_handler)
+
+    def search(self, request_handler=u'/select', query=u'*:*', filters=None,
+               start=0, rows=1000, sort=None, **params):
+        return self._search(
+            request_handler=request_handler, query=query, filters=filters,
+            start=start, rows=rows, sort=sort, unrestricted=False, **params)
+
+    def unrestricted_search(self, request_handler=u'/select', query=u'*:*',
+                            filters=None, start=0, rows=1000, sort=None, **params):
+        return self._search(
+            request_handler=request_handler, query=query, filters=filters,
+            start=start, rows=rows, sort=sort, unrestricted=True, **params)
 
     def security_filter(self):
         user = getSecurityManager().getUser()

--- a/ftw/solr/tests/test_search.py
+++ b/ftw/solr/tests/test_search.py
@@ -105,3 +105,20 @@ class TestSearch(unittest.TestCase):
         self.solr.search(request_handler='/query')
         args, kwargs = self.conn.search.call_args
         self.assertEqual(kwargs, {'request_handler': u'/query'})
+
+    def test_search_contains_security_filters(self):
+        self.solr.search()
+        args, kwargs = self.conn.search.call_args
+        self.assertEqual(
+            args[0][u'filter'],
+            [u'allowedRolesAndUsers:(Member OR Authenticated OR Anonymous OR '
+             u'user\\:AuthenticatedUsers OR user\\:test_user_1_)'])
+
+    def test_search_does_not_allow_unrestricted_keyword(self):
+        with self.assertRaises(TypeError):
+            self.solr.search(unrestricted=True)
+
+    def test_unrestricted_search_does_not_contain_security_filters(self):
+        self.solr.unrestricted_search()
+        args, kwargs = self.conn.search.call_args
+        self.assertEqual(args[0][u'filter'], [])


### PR DESCRIPTION
Solr queries are now also used in some upgrade steps / maintenance jobs. As such it seems important to ensure that no objects are omitted because of restricted access. Of course normally this should not make any difference, as the user executing the upgrades / maintenance is manager, but typically an object with broken `allowedRolesAndUsers` index would be invisible in normal search...

For https://4teamwork.atlassian.net/browse/CA-1335