### PR TITLE
Add flag to force clear solr even if not enabled.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2.9.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add flag to force clearing solr even when solr is not enabled. [njohner]
 
 
 2.9.5 (2021-08-17)

--- a/ftw/solr/browser/maintenance.py
+++ b/ftw/solr/browser/maintenance.py
@@ -119,9 +119,9 @@ class SolrMaintenanceView(BrowserView):
         conn.optimize()
         return 'Solr index optimized.'
 
-    def clear(self):
+    def clear(self, force=False):
         """Clear all data from Solr index."""
-        if not self.is_enabled():
+        if not force and not self.is_enabled():
             return 'Solr indexing is disabled.'
         conn = self.manager.connection
         conn.delete_by_query('*:*')


### PR DESCRIPTION
This is used when wiping and setting up Gever again. See https://github.com/4teamwork/opengever.core/pull/7180