### PR TITLE
Update / rebase python3 compatibility from @buchi

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,6 +80,19 @@ After running buildout and restarting your instance you can install the ftw.solr
 addon in Plone.
 
 
+Python 3.7 - Plone 5.2
+----------------------
+
+Install and run tests locally:
+
+.. code::
+
+    python3 -m venv .
+    ./bin/pip install -r requirements.txt
+    ./bin/buildout -c test-plone-5.2.x-py37.cfg
+    ./bin/test
+
+
 Usage
 =====
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -1,10 +1,11 @@
 Changelog
 =========
 
-2.10.1 (unreleased)
+2.11.0 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Add support for Plone 5.2 and Python 3.
+  [buchi]
 
 
 2.10.0 (2021-09-21)

--- a/ftw/solr/browser/maintenance.py
+++ b/ftw/solr/browser/maintenance.py
@@ -19,6 +19,7 @@ from time import time
 from zope.component import getMultiAdapter
 from zope.component import queryUtility
 from zope.component.hooks import getSite
+
 import logging
 from logging.handlers import TimedRotatingFileHandler
 import transaction
@@ -149,7 +150,7 @@ class SolrMaintenanceView(BrowserView):
             zodb_conn.cacheGC()
             self.log(
                 'Intermediate commit (%d items processed, last batch in %s)',
-                processed, lap.next())
+                processed, next(lap))
 
         cpi = checkpoint_iterator(commit, interval=commit_interval)
         self.log('Reindexing Solr...')
@@ -161,13 +162,13 @@ class SolrMaintenanceView(BrowserView):
             handler = getMultiAdapter((obj, self.manager), ISolrIndexHandler)
             handler.add(idxs)
             processed += 1
-            cpi.next()
+            next(cpi)
 
         commit()
         self.log('Solr index rebuilt.')
         self.log(
             'Processed %d items in %s (%s cpu time).',
-            processed, real.next(), cpu.next())
+            processed, next(real), next(cpu))
 
     def reindex_cataloged(self, commit_interval=100, idxs=None, start=0,
                           end=-1, query=None, doom=True):
@@ -210,7 +211,7 @@ class SolrMaintenanceView(BrowserView):
             zodb_conn.cacheGC()
             self.log(
                 'Intermediate commit (%d items processed, last batch in %s)',
-                processed, lap.next())
+                processed, next(lap))
 
         cpi = checkpoint_iterator(commit, interval=commit_interval)
         self.log('Reindexing Solr...')
@@ -225,13 +226,13 @@ class SolrMaintenanceView(BrowserView):
             handler = getMultiAdapter((obj, self.manager), ISolrIndexHandler)
             handler.add(idxs)
             processed += 1
-            cpi.next()
+            next(cpi)
 
         commit()
         self.log('Solr index rebuilt.')
         self.log(
             'Processed %d items in %s (%s cpu time).',
-            processed, real.next(), cpu.next())
+            processed, next(real), next(cpu))
 
     def diff(self, max_diff=5):
         """Diff with portal catalog"""
@@ -314,7 +315,7 @@ class SolrMaintenanceView(BrowserView):
             zodb_conn.cacheGC()
             self.log(
                 'Intermediate commit (%d items processed, last batch in %s)',
-                processed, lap.next())
+                processed, next(lap))
 
         cpi = checkpoint_iterator(commit, interval=commit_interval)
         self.log('Syncing Solr...')
@@ -325,7 +326,7 @@ class SolrMaintenanceView(BrowserView):
             handler = getMultiAdapter((obj, self.manager), ISolrIndexHandler)
             handler.add(idxs)
             processed += 1
-            cpi.next()
+            next(cpi)
 
         commit()
 
@@ -338,7 +339,7 @@ class SolrMaintenanceView(BrowserView):
         self.log('Solr index synced.')
         self.log(
             'Processed %d items in %s (%s cpu time).',
-            processed, real.next(), cpu.next())
+            processed, next(real), next(cpu))
 
     def log(self, msg, *args):
         logger.info(msg, *args)

--- a/ftw/solr/commands.py
+++ b/ftw/solr/commands.py
@@ -4,6 +4,7 @@ from Products.CMFPlone.interfaces import IPloneSiteRoot
 from Testing.makerequest import makerequest
 from zope.component import queryMultiAdapter
 from zope.component.hooks import setSite
+
 import argparse
 import sys
 

--- a/ftw/solr/configure.zcml
+++ b/ftw/solr/configure.zcml
@@ -25,9 +25,13 @@
   <adapter for="*
                 ftw.solr.interfaces.ISolrConnectionManager"
            factory="ftw.solr.handlers.DefaultIndexHandler" />
-  <adapter for="plone.app.blob.interfaces.IATBlobFile
-                ftw.solr.interfaces.ISolrConnectionManager"
-           factory="ftw.solr.handlers.ATBlobFileIndexHandler" />
+
+  <configure zcml:condition="installed plone.app.blob"> 
+    <adapter for="plone.app.blob.interfaces.IATBlobFile
+                  ftw.solr.interfaces.ISolrConnectionManager"
+             factory="ftw.solr.handlers.ATBlobFileIndexHandler" />
+  </configure>
+
   <adapter for="plone.dexterity.interfaces.IDexterityItem
                 ftw.solr.interfaces.ISolrConnectionManager"
            factory="ftw.solr.handlers.DexterityItemIndexHandler" />

--- a/ftw/solr/connection.py
+++ b/ftw/solr/connection.py
@@ -4,13 +4,14 @@ from ftw.solr.helpers import http_chunked_encoder
 from ftw.solr.interfaces import ISolrConnectionConfig
 from ftw.solr.interfaces import ISolrConnectionManager
 from ftw.solr.schema import SolrSchema
-from httplib import HTTPConnection
-from httplib import HTTPException
 from logging import getLogger
+from six.moves.http_client import HTTPConnection
+from six.moves.http_client import HTTPException
+from six.moves.urllib.parse import urlencode
 from threading import local
-from urllib import urlencode
 from zope.component import queryUtility
 from zope.interface import implementer
+
 import json
 import os.path
 import socket

--- a/ftw/solr/connection.py
+++ b/ftw/solr/connection.py
@@ -209,7 +209,7 @@ class SolrConnection(object):
                     }
                     resp = self.post(
                         '/update',
-                        data=json.dumps(update_command),
+                        data=json.dumps(update_command, sort_keys=True),
                         log_error=False)
                     if not resp.is_ok():
                         logger.error(

--- a/ftw/solr/converters.py
+++ b/ftw/solr/converters.py
@@ -1,7 +1,9 @@
 from datetime import date
 from datetime import datetime
 from DateTime import DateTime
+
 import math
+import six
 
 
 def to_iso8601(value, multivalued=False):
@@ -36,7 +38,7 @@ def to_unicode(value, multivalued=False):
     if not isinstance(value, list):
         value = [value]
     for i, v in enumerate(value):
-        if isinstance(v, str):
+        if isinstance(v, six.binary_type):
             v = v.decode('utf8')
         value[i] = v
     if not multivalued:

--- a/ftw/solr/converters.py
+++ b/ftw/solr/converters.py
@@ -1,6 +1,6 @@
-from DateTime import DateTime
-from datetime import datetime
 from datetime import date
+from datetime import datetime
+from DateTime import DateTime
 import math
 
 

--- a/ftw/solr/document.py
+++ b/ftw/solr/document.py
@@ -11,7 +11,7 @@ import six
 class SolrDocument(object):
 
     def __init__(self, data, fields=None):
-        self.data = unicode2bytes(data)
+        self.data = text2str(data)
         self.fields = fields or list()
 
     def __getitem__(self, key):
@@ -70,12 +70,12 @@ class SolrDocument(object):
             return None
 
 
-def unicode2bytes(data):
+def text2str(data):
     if isinstance(data, six.text_type):
-        return data.encode('utf8')
+        return six.ensure_str(data)
     elif isinstance(data, dict):
-        return dict(map(unicode2bytes, six.iteritems(data)))
+        return dict(map(text2str, six.iteritems(data)))
     elif isinstance(data, (list, tuple)):
-        return list(map(unicode2bytes, data))
+        return list(map(text2str, data))
     else:
         return data

--- a/ftw/solr/document.py
+++ b/ftw/solr/document.py
@@ -1,7 +1,10 @@
 from ftw.solr.interfaces import ISolrDocument
+from six.moves import map
 from zope.component.hooks import getSite
 from zope.globalrequest import getRequest
 from zope.interface import implementer
+
+import six
 
 
 @implementer(ISolrDocument)
@@ -68,10 +71,10 @@ class SolrDocument(object):
 
 
 def unicode2bytes(data):
-    if isinstance(data, unicode):
+    if isinstance(data, six.text_type):
         return data.encode('utf8')
     elif isinstance(data, dict):
-        return dict(map(unicode2bytes, data.iteritems()))
+        return dict(map(unicode2bytes, six.iteritems(data)))
     elif isinstance(data, (list, tuple)):
         return list(map(unicode2bytes, data))
     else:

--- a/ftw/solr/handlers.py
+++ b/ftw/solr/handlers.py
@@ -1,10 +1,10 @@
-from Products.CMFCore.utils import getToolByName
 from ftw.solr.converters import CONVERTERS
 from ftw.solr.interfaces import ISolrIndexHandler
 from logging import getLogger
 from plone.indexer.interfaces import IIndexableObject
 from plone.namedfile.interfaces import INamedBlobFile
 from plone.rfc822.interfaces import IPrimaryFieldInfo
+from Products.CMFCore.utils import getToolByName
 from zope.component import queryMultiAdapter
 from zope.interface import implementer
 
@@ -146,7 +146,7 @@ class ATBlobFileIndexHandler(DefaultIndexHandler):
             return
 
         if attributes is None:
-            attributes = self.manager.schema.fields.keys()
+            attributes = list(self.manager.schema.fields)
 
         extract = False
         if 'SearchableText' in attributes:
@@ -196,7 +196,7 @@ class DexterityItemIndexHandler(DefaultIndexHandler):
             content_type = info.value.contentType
 
         if not attributes:
-            attributes = self.manager.schema.fields.keys()
+            attributes = list(self.manager.schema.fields)
 
         extract = False
         if 'SearchableText' in attributes and blob is not None:

--- a/ftw/solr/helpers.py
+++ b/ftw/solr/helpers.py
@@ -1,5 +1,5 @@
 from functools import partial
-from itertools import izip
+from six.moves import zip
 
 
 MAXCHUNKSIZE = 1 << 16
@@ -8,7 +8,7 @@ MAXCHUNKSIZE = 1 << 16
 def group_by_two(iterable):
     # group_by_two('ABCDEFG') --> AB CD EF
     args = [iter(iterable)] * 2
-    return izip(*args)
+    return zip(*args)
 
 
 def chunked_file_reader(open_file, chunk_size=MAXCHUNKSIZE):

--- a/ftw/solr/patches.py
+++ b/ftw/solr/patches.py
@@ -9,6 +9,7 @@ from Products.CMFCore.interfaces._content import ICatalogAware
 from Products.CMFCore.utils import getToolByName
 from zope.component import queryMultiAdapter
 
+
 if not PLONE51:
     # Make sure collective.indexing patches are applied before our patches
     import collective.indexing.monkey  # noqa

--- a/ftw/solr/patches.py
+++ b/ftw/solr/patches.py
@@ -1,14 +1,23 @@
 from ftw.solr.interfaces import PLONE51
 from plone.indexer.interfaces import IIndexer
-from Products.Archetypes.CatalogMultiplex import CatalogMultiplex
-from Products.Archetypes.config import TOOL_NAME
-from Products.Archetypes.utils import isFactoryContained
 from Products.CMFCore.CMFCatalogAware import CMFCatalogAware
 from Products.CMFCore.interfaces import ICatalogTool
 from Products.CMFCore.interfaces._content import ICatalogAware
 from Products.CMFCore.utils import getToolByName
 from zope.component import queryMultiAdapter
 
+import pkg_resources
+
+
+try:
+    pkg_resources.get_distribution("Products.Archetypes")
+except pkg_resources.DistributionNotFound:
+    HAS_AT = False
+else:
+    HAS_AT = True
+    from Products.Archetypes.CatalogMultiplex import CatalogMultiplex
+    from Products.Archetypes.config import TOOL_NAME
+    from Products.Archetypes.utils import isFactoryContained
 
 if not PLONE51:
     # Make sure collective.indexing patches are applied before our patches
@@ -161,22 +170,6 @@ def recursive_index_security(catalog, obj, skip_self=False):
             recursive_index_security(catalog, subobj)
 
 
-def ftw_solr_CatalogMultiplex_reindexObjectSecurity(self, skip_self=False):
-    """Update security information in all registered catalogs.
-    """
-    if isFactoryContained(self):
-        return
-    at = getToolByName(self, TOOL_NAME, None)
-    if at is None:
-        return
-
-    catalogs = [c for c in at.getCatalogsByType(self.meta_type)
-                if ICatalogTool.providedBy(c)]
-
-    for catalog in catalogs:
-        recursive_index_security(catalog, self, skip_self=skip_self)
-
-
 def ftw_solr_CatalogAware_reindexObjectSecurity(self, skip_self=False):
     """Reindex security-related indexes on the object.
     """
@@ -189,6 +182,23 @@ def ftw_solr_CatalogAware_reindexObjectSecurity(self, skip_self=False):
     if s is None:
         self._p_deactivate()
 
-
 CMFCatalogAware.reindexObjectSecurity = ftw_solr_CatalogAware_reindexObjectSecurity  # noqa
-CatalogMultiplex.reindexObjectSecurity = ftw_solr_CatalogMultiplex_reindexObjectSecurity  # noqa
+
+
+if HAS_AT:
+    def ftw_solr_CatalogMultiplex_reindexObjectSecurity(self, skip_self=False):
+        """Update security information in all registered catalogs.
+        """
+        if isFactoryContained(self):
+            return
+        at = getToolByName(self, TOOL_NAME, None)
+        if at is None:
+            return
+
+        catalogs = [c for c in at.getCatalogsByType(self.meta_type)
+                    if ICatalogTool.providedBy(c)]
+
+        for catalog in catalogs:
+            recursive_index_security(catalog, self, skip_self=skip_self)
+
+    CatalogMultiplex.reindexObjectSecurity = ftw_solr_CatalogMultiplex_reindexObjectSecurity  # noqa

--- a/ftw/solr/query.py
+++ b/ftw/solr/query.py
@@ -3,6 +3,7 @@ from ftw.solr.interfaces import ISolrConnectionManager
 from ftw.solr.interfaces import ISolrSettings
 from logging import getLogger
 from plone.registry.interfaces import IRegistry
+from six.moves import range
 from zope.component import getUtility
 from ZPublisher.HTTPRequest import record
 

--- a/ftw/solr/query.py
+++ b/ftw/solr/query.py
@@ -8,6 +8,7 @@ from zope.component import getUtility
 from ZPublisher.HTTPRequest import record
 
 import re
+import six
 
 logger = getLogger('ftw.solr.query')
 
@@ -58,7 +59,7 @@ def split_simple_search(phrase):
 
 def make_query(phrase):
     phrase = phrase.strip()
-    if isinstance(phrase, str):
+    if isinstance(phrase, six.binary_type):
         phrase = phrase.decode('utf8')
     registry = getUtility(IRegistry)
     settings = registry.forInterface(ISolrSettings)

--- a/ftw/solr/testing.py
+++ b/ftw/solr/testing.py
@@ -8,7 +8,16 @@ from plone.app.testing import PloneSandboxLayer
 from plone.testing import z2
 
 import ftw.solr
+import pkg_resources
 import plone.app.contenttypes
+
+
+try:
+    pkg_resources.get_distribution("Products.Archetypes")
+except pkg_resources.DistributionNotFound:
+    HAS_AT = False
+else:
+    HAS_AT = True
 
 
 class FtwSolrLayer(PloneSandboxLayer):
@@ -31,37 +40,45 @@ class FtwSolrLayer(PloneSandboxLayer):
         applyProfile(portal, 'ftw.solr:default')
 
 
-class FtwSolrATLayer(PloneSandboxLayer):
-
-    defaultBases = (PLONE_FIXTURE,)
-
-    def setUpZope(self, app, configurationContext):
-        if not PLONE51:
-            import collective.indexing
-            self.loadZCML(package=collective.indexing)
-            z2.installProduct(app, 'collective.indexing')
-
-        self.loadZCML(package=ftw.solr)
-        z2.installProduct(app, 'ftw.solr')
-
-    def setUpPloneSite(self, portal):
-        applyProfile(portal, 'ftw.solr:default')
-
-
 FTW_SOLR_FIXTURE = FtwSolrLayer()
-FTW_SOLR_AT_FIXTURE = FtwSolrATLayer()
 
 FTW_SOLR_INTEGRATION_TESTING = IntegrationTesting(
     bases=(FTW_SOLR_FIXTURE,),
     name='FtwSolrLayer:IntegrationTesting'
 )
 
-FTW_SOLR_AT_INTEGRATION_TESTING = IntegrationTesting(
-    bases=(FTW_SOLR_AT_FIXTURE,),
-    name='FtwSolrATLayer:IntegrationTesting'
-)
 
 FTW_SOLR_FUNCTIONAL_TESTING = FunctionalTesting(
     bases=(FTW_SOLR_FIXTURE,),
     name='FtwSolrLayer:FunctionalTesting'
 )
+
+if HAS_AT:
+    class FtwSolrATLayer(PloneSandboxLayer):
+
+        defaultBases = (PLONE_FIXTURE,)
+
+        def setUpZope(self, app, configurationContext):
+            if not PLONE51:
+                import collective.indexing
+                self.loadZCML(package=collective.indexing)
+                z2.installProduct(app, 'collective.indexing')
+
+            self.loadZCML(package=ftw.solr)
+            z2.installProduct(app, 'ftw.solr')
+
+        def setUpPloneSite(self, portal):
+            applyProfile(portal, 'ftw.solr:default')
+
+    FTW_SOLR_AT_FIXTURE = FtwSolrATLayer()
+
+    FTW_SOLR_AT_INTEGRATION_TESTING = IntegrationTesting(
+        bases=(FTW_SOLR_AT_FIXTURE,),
+        name='FtwSolrATLayer:IntegrationTesting'
+    )
+else:
+    FTW_SOLR_AT_FIXTURE = FtwSolrLayer()
+    FTW_SOLR_AT_INTEGRATION_TESTING = IntegrationTesting(
+        bases=(FTW_SOLR_FIXTURE,),
+        name='FtwSolrLayer:IntegrationTesting'
+    )

--- a/ftw/solr/testing.py
+++ b/ftw/solr/testing.py
@@ -6,6 +6,7 @@ from plone.app.testing import IntegrationTesting
 from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PloneSandboxLayer
 from plone.testing import z2
+
 import ftw.solr
 import plone.app.contenttypes
 

--- a/ftw/solr/tests/test_connection.py
+++ b/ftw/solr/tests/test_connection.py
@@ -3,17 +3,18 @@ from ftw.solr.connection import SolrConnection
 from ftw.solr.connection import SolrConnectionConfig
 from ftw.solr.connection import SolrConnectionManager
 from ftw.solr.connection import SolrResponse
-from ftw.solr.tests.utils import get_data
-from ftw.solr.tests.utils import MockHTTPResponse
-from ftw.solr.tests.utils import MockBlob
 from ftw.solr.interfaces import ISolrConnectionConfig
-from mock import patch
+from ftw.solr.tests.utils import get_data
+from ftw.solr.tests.utils import MockBlob
+from ftw.solr.tests.utils import MockHTTPResponse
 from mock import MagicMock
-from zope.component import provideUtility
+from mock import patch
 from plone.testing import zca
-import unittest
-import transaction
+from zope.component import provideUtility
+
 import socket
+import transaction
+import unittest
 
 
 class TestConnection(unittest.TestCase):

--- a/ftw/solr/tests/test_connection.py
+++ b/ftw/solr/tests/test_connection.py
@@ -132,8 +132,8 @@ class TestConnection(unittest.TestCase):
         self.assertEqual(args, ('/update',))
         self.assertEqual(
             kwargs,
-            {'data': '{"add": {"doc": {"id": "1", "SearchableText": {"set": "T'
-                     'he searchable text"}}}}',
+            {'data': '{"add": {"doc": {"SearchableText": {"set": "The '
+                     'searchable text"}, "id": "1"}}}',
              'log_error': False})
         self.assertEqual(conn.extract_commands, [])
 
@@ -163,8 +163,8 @@ class TestConnection(unittest.TestCase):
 
         self.assertEqual(
             (('/update',),
-             {'data': '{"add": {"doc": {"UID": "1", "SearchableText": {"set": '
-                      '"The searchable text"}}}}',
+             {'data': '{"add": {"doc": {"SearchableText": {"set": '
+                      '"The searchable text"}, "UID": "1"}}}',
               'log_error': False}),
             conn.post.call_args_list[1])
 
@@ -176,8 +176,8 @@ class TestConnection(unittest.TestCase):
 
         self.assertEqual(
             (('/update',),
-             {'data': '{"add": {"doc": {"UID": "2", "SearchableText": {"set": '
-                      '"The searchable text"}}}}',
+             {'data': '{"add": {"doc": {"SearchableText": {"set": '
+                      '"The searchable text"}, "UID": "2"}}}',
               'log_error': False}),
             conn.post.call_args_list[3])
 
@@ -193,7 +193,6 @@ class TestConnection(unittest.TestCase):
                       '"The searchable text"}, "UID": "1"}}}',
               'log_error': False}),
             conn.post.call_args_list[5])
-
         self.assertEqual(conn.extract_commands, [])
 
     def test_flush_operation_posts_extract_commands_with_blobs_if_configured(self):
@@ -221,9 +220,10 @@ class TestConnection(unittest.TestCase):
         self.assertEqual(args, ('/update',))
         self.assertEqual(
             kwargs,
-            {'data': '{"add": {"doc": {"id": "1", "SearchableText": {"set": "T'
-                     'he searchable text"}}}}',
+            {'data': '{"add": {"doc": {"SearchableText": {"set": "The '
+                     'searchable text"}, "id": "1"}}}',
              'log_error': False})
+
         self.assertEqual(conn.extract_commands, [])
 
     def test_flush_operation_without_after_commit_hook(self):
@@ -247,8 +247,8 @@ class TestConnection(unittest.TestCase):
         self.assertEqual(args, ('/update',))
         self.assertEqual(
             kwargs,
-            {'data': '{"add": {"doc": {"id": "1", "SearchableText": {"set": "T'
-                     'he searchable text"}}}}',
+            {'data': '{"add": {"doc": {"SearchableText": {"set": "The '
+                     'searchable text"}, "id": "1"}}}',
              'log_error': False})
 
         self.assertEqual(conn.extract_commands, [])

--- a/ftw/solr/tests/test_connection.py
+++ b/ftw/solr/tests/test_connection.py
@@ -12,12 +12,18 @@ from mock import patch
 from plone.testing import zca
 from zope.component import provideUtility
 
+import json
 import socket
 import transaction
 import unittest
 
 
 class TestConnection(unittest.TestCase):
+
+    def assert_equal_commands(self, first, second):
+        return self.assertEqual(
+            json.loads('{' + ','.join(first) + '}'),
+            json.loads('{' + ','.join(second) + '}'))
 
     def test_connection_initialization(self):
         conn = SolrConnection(host='mysolrserver', base='/solr/mycore')
@@ -82,7 +88,7 @@ class TestConnection(unittest.TestCase):
         conn.flush = MagicMock(name='flush')
         conn.commit()
         conn.flush.assert_called_once_with(extract_after_commit=True)
-        self.assertEqual(
+        self.assert_equal_commands(
             conn.update_commands,
             ['"commit": {"softCommit": true, "waitSearcher": true}'])
 

--- a/ftw/solr/tests/test_contentlisting.py
+++ b/ftw/solr/tests/test_contentlisting.py
@@ -92,11 +92,11 @@ class TestContentListingObject(unittest.TestCase):
 
     def test_idublincore_created(self):
         self.assertEqual(
-            self.obj.created(), DateTime('2017/08/01 13:17:0.009000 GMT+2'))
+            self.obj.created(zone='utc'), DateTime('2017/08/01 11:17:0.009000 UTC'))
 
     def test_idublincore_modified(self):
         self.assertEqual(
-            self.obj.modified(), DateTime('2017/12/31 12:17:0.137000 GMT+1'))
+            self.obj.modified(zone='utc'), DateTime('2017/12/31 11:17:0.137000 UTC'))
 
     def test_idublincore_effective(self):
         self.assertEqual(
@@ -108,11 +108,11 @@ class TestContentListingObject(unittest.TestCase):
 
     def test_idublincore_creationdate(self):
         self.assertEqual(
-            self.obj.CreationDate(), '2017-08-01T13:17:00+02:00')
+            self.obj.CreationDate(zone='utc'), '2017-08-01T11:17:00+00:00')
 
     def test_idublincore_modificationdate(self):
         self.assertEqual(
-            self.obj.ModificationDate(), '2017-12-31T12:17:00+01:00')
+            self.obj.ModificationDate(zone='utc'), '2017-12-31T11:17:00+00:00')
 
     def test_idublincore_effectivedate(self):
         self.assertEqual(

--- a/ftw/solr/tests/test_converters.py
+++ b/ftw/solr/tests/test_converters.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 from datetime import date
-from DateTime import DateTime
 from datetime import datetime
+from DateTime import DateTime
 from ftw.solr.converters import to_iso8601
 from ftw.solr.converters import to_unicode
+
 import pytz
+import six
 import unittest
 
 
@@ -12,59 +14,59 @@ class TestDateTimeConverter(unittest.TestCase):
 
     def test_zope_datetime_in_utc_converts_to_iso8601(self):
         dt = to_iso8601(DateTime('2017-10-21 14:28:16.936207 UTC'))
-        self.assertIsInstance(dt, unicode)
+        self.assertIsInstance(dt, six.text_type)
         self.assertEqual(dt, u'2017-10-21T14:28:16.936Z')
 
     def test_zope_datetime_in_gmt2_converts_to_iso8601(self):
         dt = to_iso8601(DateTime('2017-10-21 16:28:16.936207 GMT+2'))
-        self.assertIsInstance(dt, unicode)
+        self.assertIsInstance(dt, six.text_type)
         self.assertEqual(dt, u'2017-10-21T14:28:16.936Z')
 
     def test_python_datetime_timezone_naive_converts_to_iso8601(self):
         dt = to_iso8601(datetime(2017, 10, 21, 14, 28, 16, 936207))
-        self.assertIsInstance(dt, unicode)
+        self.assertIsInstance(dt, six.text_type)
         self.assertEqual(dt, u'2017-10-21T14:28:16.936Z')
 
     def test_python_datetime_timezone_aware_converts_to_iso8601(self):
         tz = pytz.timezone('Europe/Zurich')
         dt = to_iso8601(tz.localize(
             datetime(2017, 10, 21, 16, 28, 16, 936207)))
-        self.assertIsInstance(dt, unicode)
+        self.assertIsInstance(dt, six.text_type)
         self.assertEqual(dt, u'2017-10-21T14:28:16.936Z')
 
     def test_datetime_before_1900_converts_to_iso8601(self):
         dt = to_iso8601(datetime(1871, 3, 30, 1, 2))
-        self.assertIsInstance(dt, unicode)
+        self.assertIsInstance(dt, six.text_type)
         self.assertEqual(dt, u'1871-03-30T01:02:00.000Z')
 
     def test_datetime_before_1000_converts_to_iso8601(self):
         dt = to_iso8601(datetime(971, 3, 30, 17))
-        self.assertIsInstance(dt, unicode)
+        self.assertIsInstance(dt, six.text_type)
         self.assertEqual(dt, u'0971-03-30T17:00:00.000Z')
 
     def test_datetime_before_100_converts_to_iso8601(self):
         dt = to_iso8601(datetime(71, 3, 30))
-        self.assertIsInstance(dt, unicode)
+        self.assertIsInstance(dt, six.text_type)
         self.assertEqual(dt, u'0071-03-30T00:00:00.000Z')
 
     def test_python_date_converts_to_iso8601(self):
         dt = to_iso8601(date(2017, 10, 21))
-        self.assertIsInstance(dt, unicode)
+        self.assertIsInstance(dt, six.text_type)
         self.assertEqual(dt, u'2017-10-21T00:00:00.000Z')
 
     def test_date_before_1900_converts_to_iso8601(self):
         dt = to_iso8601(date(1871, 3, 30))
-        self.assertIsInstance(dt, unicode)
+        self.assertIsInstance(dt, six.text_type)
         self.assertEqual(dt, u'1871-03-30T00:00:00.000Z')
 
     def test_date_before_1000_converts_to_iso8601(self):
         dt = to_iso8601(date(971, 3, 30))
-        self.assertIsInstance(dt, unicode)
+        self.assertIsInstance(dt, six.text_type)
         self.assertEqual(dt, u'0971-03-30T00:00:00.000Z')
 
     def test_date_before_100_converts_to_iso8601(self):
         dt = to_iso8601(date(71, 3, 30))
-        self.assertIsInstance(dt, unicode)
+        self.assertIsInstance(dt, six.text_type)
         self.assertEqual(dt, u'0071-03-30T00:00:00.000Z')
 
     def test_invalid_date_converts_to_none(self):
@@ -73,25 +75,25 @@ class TestDateTimeConverter(unittest.TestCase):
 
     def test_zope_datetime_high_millis_does_not_cause_rounding_error_low(self):
         dt = to_iso8601(DateTime('2017-10-21 16:28:59.999501'))
-        self.assertIsInstance(dt, unicode)
+        self.assertIsInstance(dt, six.text_type)
         self.assertNotEqual(dt, u'2017-10-21T16:28:60.000Z')
         self.assertEqual(dt, u'2017-10-21T16:28:59.999Z')
 
     def test_zope_datetime_high_millis_does_not_cause_rounding_error_high(self):
         dt = to_iso8601(DateTime('2017-10-21 16:28:59.999999'))
-        self.assertIsInstance(dt, unicode)
+        self.assertIsInstance(dt, six.text_type)
         self.assertNotEqual(dt, u'2017-10-21T16:28:60.000Z')
         self.assertEqual(dt, u'2017-10-21T16:28:59.999Z')
 
     def test_datetime_high_millis_does_not_cause_rounding_error_low(self):
         dt = to_iso8601(datetime(2017, 10, 21, 16, 28, 59, 999501))
-        self.assertIsInstance(dt, unicode)
+        self.assertIsInstance(dt, six.text_type)
         self.assertNotEqual(dt, u'2017-10-21T16:28:60.000Z')
         self.assertEqual(dt, u'2017-10-21T16:28:59.999Z')
 
     def test_datetime_high_millis_does_not_cause_rounding_error_high(self):
         dt = to_iso8601(datetime(2017, 10, 21, 16, 28, 59, 999999))
-        self.assertIsInstance(dt, unicode)
+        self.assertIsInstance(dt, six.text_type)
         self.assertNotEqual(dt, u'2017-10-21T16:28:60.000Z')
         self.assertEqual(dt, u'2017-10-21T16:28:59.999Z')
 
@@ -112,32 +114,32 @@ class TestStringConverter(unittest.TestCase):
 
     def test_bytestring_converts_to_unicode(self):
         string = to_unicode('fünf vor zwölf')
-        self.assertIsInstance(string, unicode)
+        self.assertIsInstance(string, six.text_type)
         self.assertEqual(string, u'fünf vor zwölf')
 
     def test_unicode_converts_to_unicode(self):
         string = to_unicode(u'fünf vor zwölf')
-        self.assertIsInstance(string, unicode)
+        self.assertIsInstance(string, six.text_type)
         self.assertEqual(string, u'fünf vor zwölf')
 
     def test_list_of_bytestrings_converts_to_list_of_unicode(self):
         strings = to_unicode(['fünf', 'vor', 'zwölf'], multivalued=True)
         for string in strings:
-            self.assertIsInstance(string, unicode)
+            self.assertIsInstance(string, six.text_type)
         self.assertEqual(strings, [u'fünf', u'vor', u'zwölf'])
 
     def test_tuple_of_bytestrings_converts_to_list_of_unicode(self):
         strings = to_unicode(('fünf', 'vor', 'zwölf'), multivalued=True)
         for string in strings:
-            self.assertIsInstance(string, unicode)
+            self.assertIsInstance(string, six.text_type)
         self.assertEqual(strings, [u'fünf', u'vor', u'zwölf'])
 
     def test_list_of_bytestrings_converts_to_unicode(self):
         string = to_unicode(['fünf', 'vor', 'zwölf'])
-        self.assertIsInstance(string, unicode)
+        self.assertIsInstance(string, six.text_type)
         self.assertEqual(string, u'fünf vor zwölf')
 
     def test_bytestring_converts_to_list_of_unicode(self):
         string = to_unicode('fünf vor zwölf', multivalued=True)
-        self.assertIsInstance(string[0], unicode)
+        self.assertIsInstance(string[0], six.text_type)
         self.assertEqual(string, [u'fünf vor zwölf'])

--- a/ftw/solr/tests/test_document.py
+++ b/ftw/solr/tests/test_document.py
@@ -4,6 +4,7 @@ from ftw.solr.testing import FTW_SOLR_INTEGRATION_TESTING
 from ftw.solr.tests.utils import get_data
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
+
 import json
 import unittest
 

--- a/ftw/solr/tests/test_handlers.py
+++ b/ftw/solr/tests/test_handlers.py
@@ -20,6 +20,7 @@ from plone.namedfile.file import NamedBlobFile
 from plone.uuid.interfaces import IMutableUUID
 from Products.CMFPlone.utils import base_hasattr
 from Products.CMFPlone.utils import getFSVersionTuple
+
 import unittest
 
 

--- a/ftw/solr/tests/test_helpers.py
+++ b/ftw/solr/tests/test_helpers.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from ftw.solr.helpers import chunked_file_reader
 from ftw.solr.helpers import http_chunked_encoder
-from StringIO import StringIO
+from six import StringIO
 
 import unittest
 

--- a/ftw/solr/tests/test_helpers.py
+++ b/ftw/solr/tests/test_helpers.py
@@ -2,6 +2,7 @@
 from ftw.solr.helpers import chunked_file_reader
 from ftw.solr.helpers import http_chunked_encoder
 from StringIO import StringIO
+
 import unittest
 
 

--- a/ftw/solr/tests/test_indexer.py
+++ b/ftw/solr/tests/test_indexer.py
@@ -13,6 +13,7 @@ from zope.component import provideAdapter
 from zope.component import provideUtility
 from zope.component import queryUtility
 from zope.interface import Interface
+
 import unittest
 
 

--- a/ftw/solr/tests/test_integration.py
+++ b/ftw/solr/tests/test_integration.py
@@ -20,6 +20,7 @@ from plone.app.testing import TEST_USER_NAME
 from plone.uuid.interfaces import IUUID
 from zope.component import getUtility
 from zope.interface import alsoProvides
+
 import unittest
 
 

--- a/ftw/solr/tests/test_integration.py
+++ b/ftw/solr/tests/test_integration.py
@@ -21,6 +21,7 @@ from Products.CMFPlone.utils import getFSVersionTuple
 from zope.component import getUtility
 from zope.interface import alsoProvides
 
+import pytz
 import six
 import unittest
 
@@ -115,7 +116,7 @@ class TestIntegration(unittest.TestCase):
         )
 
     def test_reindex_object_causes_full_reindex_in_solr(self):
-        with freeze(datetime(2018, 8, 31, 13, 45)):
+        with freeze(datetime(2018, 8, 31, 13, 45, tzinfo=pytz.UTC)):
             self.subfolder.reindexObject()
         getQueue().process()
 
@@ -125,7 +126,7 @@ class TestIntegration(unittest.TestCase):
             {
                 u'UID': IUUID(self.subfolder),
                 u'Title': u'My Subfolder',
-                u'modified': u'2018-08-31T11:45:00.000Z',
+                u'modified': u'2018-08-31T13:45:00.000Z',
                 u'SearchableText': u'subfolder My Subfolder',
                 u'allowedRolesAndUsers': [u'Other'],
                 u'path': u'/plone/folder/subfolder',

--- a/ftw/solr/tests/test_integration.py
+++ b/ftw/solr/tests/test_integration.py
@@ -100,7 +100,7 @@ class TestIntegration(unittest.TestCase):
         data['SearchableText'] = normalize_whitespaces(data['SearchableText'])
         self.assertEqual(
             {
-                u'UID': IUUID(self.subfolder).decode('utf8'),
+                u'UID': IUUID(self.subfolder),
                 u'Title': u'My Subfolder',
                 u'modified': u'2018-08-31T11:45:00.000Z',
                 u'SearchableText': u'subfolder My Subfolder',

--- a/ftw/solr/tests/test_query.py
+++ b/ftw/solr/tests/test_query.py
@@ -15,6 +15,8 @@ from plone.registry.interfaces import IRegistry
 from plone.testing import zca
 from zope.component import provideAdapter
 from zope.component import provideUtility
+
+import six
 import unittest
 
 
@@ -114,8 +116,8 @@ class TestMakeQuery(unittest.TestCase):
             u'AND (Title:eight) AND (Title:nine) AND (Title:ten))')
 
     def test_query_string_is_unicode(self):
-        self.assertTrue(isinstance(make_query('über'), unicode))
-        self.assertTrue(isinstance(make_query(u'über'), unicode))
+        self.assertTrue(isinstance(make_query('über'), six.text_type))
+        self.assertTrue(isinstance(make_query(u'über'), six.text_type))
 
 
 class TestMakeFilters(unittest.TestCase):

--- a/ftw/solr/tests/test_response.py
+++ b/ftw/solr/tests/test_response.py
@@ -1,5 +1,6 @@
 from ftw.solr.connection import SolrResponse
 from ftw.solr.tests.utils import get_data
+
 import socket
 import unittest
 

--- a/ftw/solr/tests/test_schema.py
+++ b/ftw/solr/tests/test_schema.py
@@ -3,6 +3,7 @@ from ftw.solr.schema import SolrSchema
 from ftw.solr.tests.utils import get_data
 from mock import MagicMock
 from mock import PropertyMock
+
 import unittest
 
 
@@ -21,7 +22,7 @@ class TestSchema(unittest.TestCase):
         self.assertEqual(schema.version, 1.6)
         self.assertEqual(schema.unique_key, 'UID')
         self.assertItemsEqual(
-            schema.fields.keys(),
+            list(schema.fields),
             [
                 u'Title',
                 u'modified',
@@ -33,10 +34,10 @@ class TestSchema(unittest.TestCase):
                 u'path',
                 u'path_depth',
             ])
-        self.assertEqual(schema.copy_fields.keys(), [])
-        self.assertEqual(schema.dynamic_fields.keys(), [])
+        self.assertEqual(list(schema.copy_fields), [])
+        self.assertEqual(list(schema.dynamic_fields), [])
         self.assertItemsEqual(
-            schema.field_types.keys(),
+            list(schema.field_types),
             [
                 u'boolean',
                 u'string',

--- a/ftw/solr/tests/test_schema.py
+++ b/ftw/solr/tests/test_schema.py
@@ -4,6 +4,7 @@ from ftw.solr.tests.utils import get_data
 from mock import MagicMock
 from mock import PropertyMock
 
+import six
 import unittest
 
 
@@ -21,7 +22,8 @@ class TestSchema(unittest.TestCase):
         schema = self.schema
         self.assertEqual(schema.version, 1.6)
         self.assertEqual(schema.unique_key, 'UID')
-        self.assertItemsEqual(
+        six.assertCountEqual(
+            self,
             list(schema.fields),
             [
                 u'Title',
@@ -36,7 +38,8 @@ class TestSchema(unittest.TestCase):
             ])
         self.assertEqual(list(schema.copy_fields), [])
         self.assertEqual(list(schema.dynamic_fields), [])
-        self.assertItemsEqual(
+        six.assertCountEqual(
+            self,
             list(schema.field_types),
             [
                 u'boolean',

--- a/ftw/solr/tests/test_search.py
+++ b/ftw/solr/tests/test_search.py
@@ -7,6 +7,7 @@ from plone.app.testing import logout
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from zope.component import getUtility
+
 import unittest
 
 

--- a/ftw/solr/tests/test_setup.py
+++ b/ftw/solr/tests/test_setup.py
@@ -6,6 +6,12 @@ from plone import api
 import unittest
 
 
+try:
+    from Products.CMFPlone.utils import get_installer
+except ImportError:
+    get_installer = None
+
+
 class TestSetup(unittest.TestCase):
     """Test that ftw.solr is properly installed."""
 
@@ -14,12 +20,15 @@ class TestSetup(unittest.TestCase):
     def setUp(self):
         """Custom shared utility setup for tests."""
         self.portal = self.layer['portal']
-        self.installer = api.portal.get_tool('portal_quickinstaller')
 
     def test_product_installed(self):
         """Test if ftw.solr is installed."""
-        self.assertTrue(self.installer.isProductInstalled(
-            'ftw.solr'))
+        if get_installer is None:
+            installer = api.portal.get_tool('portal_quickinstaller')
+            self.assertTrue(installer.isProductInstalled('ftw.solr'))
+        else:
+            installer = get_installer(self.portal, self.portal.REQUEST)
+            self.assertTrue(installer.is_product_installed('ftw.solr'))
 
     def test_browserlayer(self):
         """Test that IFtwSolrLayer is registered."""
@@ -37,19 +46,24 @@ class TestUninstall(unittest.TestCase):
 
     def setUp(self):
         self.portal = self.layer['portal']
-        self.installer = api.portal.get_tool('portal_quickinstaller')
-        self.installer.uninstallProducts(['ftw.solr'])
+
+        if get_installer is None:
+            self.installer = api.portal.get_tool('portal_quickinstaller')
+            self.installer.uninstallProducts(['ftw.solr'])
+        else:
+            self.installer = get_installer(self.portal, self.portal.REQUEST)
+            self.installer.uninstall_product('ftw.solr')
 
     def test_product_uninstalled(self):
         """Test if ftw.solr is cleanly uninstalled."""
-        self.assertFalse(self.installer.isProductInstalled(
-            'ftw.solr'))
+        if get_installer is None:
+            self.assertFalse(self.installer.isProductInstalled('ftw.solr'))
+        else:
+            self.assertFalse(self.installer.is_product_installed('ftw.solr'))
 
     def test_browserlayer_removed(self):
         """Test that IFtwSolrLayer is removed."""
-        from ftw.solr.interfaces import \
-            IFtwSolrLayer
+        from ftw.solr.interfaces import IFtwSolrLayer
         from plone.browserlayer import utils
-        self.assertNotIn(
-           IFtwSolrLayer,
-           utils.registered_layers())
+
+        self.assertNotIn(IFtwSolrLayer, utils.registered_layers())

--- a/ftw/solr/tests/test_setup.py
+++ b/ftw/solr/tests/test_setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Setup tests for this package."""
-from plone import api
 from ftw.solr.testing import FTW_SOLR_INTEGRATION_TESTING  # noqa
+from plone import api
 
 import unittest
 

--- a/ftw/solr/tests/utils.py
+++ b/ftw/solr/tests/utils.py
@@ -4,7 +4,8 @@ import os.path
 def get_data(filename):
     """Return content from a file in the test data folder """
     filename = os.path.join(os.path.dirname(__file__), 'data', filename)
-    return open(filename, 'r').read()
+    with open(filename, 'r') as data_file:
+        return data_file.read()
 
 
 def normalize_whitespaces(text):

--- a/ftw/solr/zcml.py
+++ b/ftw/solr/zcml.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-from zope.interface import Interface
+from ftw.solr.connection import SolrConnectionConfig
+from ftw.solr.interfaces import ISolrConnectionConfig
 from zope import schema
 from zope.component.zcml import utility
-from ftw.solr.interfaces import ISolrConnectionConfig
-from ftw.solr.connection import SolrConnectionConfig
+from zope.interface import Interface
 
 
 class ISolrConnectionConfigDirective(Interface):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-zc.buildout==2.9.5
-setuptools==33.1.1
+setuptools==42.0.2
+zc.buildout==2.13.4

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ tests_require = [
 
 setup(
     name='ftw.solr',
-    version='2.10.1.dev0',
+    version='2.11.0.dev0',
     description="Solr integration for Plone",
     long_description=long_description,
     # Get more from https://pypi.python.org/pypi?%3Aaction=list_classifiers
@@ -34,8 +34,10 @@ setup(
         "Framework :: Plone :: 4.3",
         "Framework :: Plone :: 5.0",
         "Framework :: Plone :: 5.1",
+        "Framework :: Plone :: 5.2",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.7",
         "Operating System :: OS Independent",
         "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
     ],
@@ -55,6 +57,7 @@ setup(
         'plone.app.layout',
         'plone.namedfile[blobs]',
         'ftw.upgrade',
+        'six >= 1.12.0',
     ],
     extras_require=dict(
         test=tests_require,

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -6,3 +6,4 @@ package-name = ftw.solr
 test-extras = tests,cindexing
 
 [versions]
+mock = 3.0.5

--- a/test-plone-5.0.x.cfg
+++ b/test-plone-5.0.x.cfg
@@ -6,3 +6,4 @@ package-name = ftw.solr
 test-extras = tests,cindexing
 
 [versions]
+mock = 3.0.5

--- a/test-plone-5.1.x.cfg
+++ b/test-plone-5.1.x.cfg
@@ -5,3 +5,4 @@ extends =
 package-name = ftw.solr
 
 [versions]
+mock = 3.0.5

--- a/test-plone-5.2.x-py37.cfg
+++ b/test-plone-5.2.x-py37.cfg
@@ -1,0 +1,8 @@
+[buildout]
+extends =
+    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-5.2.x-py37.cfg
+
+package-name = ftw.solr
+
+[versions]
+importlib-metadata =0.23

--- a/test-plone-5.2.x-py37.cfg
+++ b/test-plone-5.2.x-py37.cfg
@@ -6,3 +6,5 @@ package-name = ftw.solr
 
 [versions]
 importlib-metadata =0.23
+setuptools=44.1.1
+zc.buildout=2.13.3

--- a/test-plone-5.2.x-py37.cfg
+++ b/test-plone-5.2.x-py37.cfg
@@ -6,5 +6,4 @@ package-name = ftw.solr
 
 [versions]
 importlib-metadata =0.23
-setuptools=44.1.1
-zc.buildout=2.13.3
+collective.xmltestreport = 2.0.2

--- a/test-plone-5.2.x.cfg
+++ b/test-plone-5.2.x.cfg
@@ -1,0 +1,8 @@
+[buildout]
+extends =
+    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-5.2.x.cfg
+
+package-name = ftw.solr
+
+[versions]
+importlib-metadata =0.23


### PR DESCRIPTION
@buchi @tisto 

I took Buchi's branch rebased and updated some tests

Local build and test was only possible via `venv` and some version pinnings -> Also see Readme:

```
    python3 -m venv .
    ./bin/pip install -r requirements.txt
    ./bin/buildout -c test-plone-5.2.x-py37.cfg
    ./bin/test
``` 

Test are passing on jenkins though.

@tisto I'll continue on a python 3.9 + plone 6 setup using the latest cookiecutter addon template (no buildout, but makefile based)

@buchi any chance this gets merged any time soon?




Further Infos:
- I fixed test, which were depending on the server's local time zone.
- Fixed `dict` order issues, by sorting the keys (various tests were depending on the dict order)