### PR TITLE
Add support for language specific fields

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2.10.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Add support for language specific fields. [buchi]
 
 
 2.10.0 (2021-09-21)

--- a/ftw/solr/config.py
+++ b/ftw/solr/config.py
@@ -1,0 +1,35 @@
+class SolrConfig(object):
+
+    def __init__(self, manager):
+        self.manager = manager
+        self.retrieve()
+
+    def retrieve(self):
+        """Retrieve the Solr config"""
+        conn = self.manager.connection
+        if conn is None:
+            self.config = {}
+        else:
+            resp = conn.get('/config')
+            self.config = resp.get(u'config', {})
+
+        # Determine language specific fields
+        self.langid_fields = []
+        self.langid_langs = []
+        self.langid_langfields = []
+        for chain in self.config.get(u'updateRequestProcessorChain', []):
+            if chain.get(u'name', u'') == u'langid':
+                processors = chain.get(u'', [])
+                for proc in processors:
+                    if 'langid.fl' in proc:
+                        self.langid_fields = proc[u'langid.fl'].split(u',')
+                        self.langid_langs = proc.get(
+                            u'langid.whitelist', u'').split(u',')
+                        fallback = proc.get(u'langid.fallback')
+                        if fallback not in self.langid_langs:
+                            self.langid_langs.append(fallback)
+                        self.langid_langfields = [
+                            u'{}_{}'.format(field, lang)
+                            for field in self.langid_fields
+                            for lang in self.langid_langs
+                        ]

--- a/ftw/solr/connection.py
+++ b/ftw/solr/connection.py
@@ -1,3 +1,4 @@
+from ftw.solr.config import SolrConfig
 from ftw.solr.helpers import chunked_file_reader
 from ftw.solr.helpers import group_by_two
 from ftw.solr.helpers import http_chunked_encoder
@@ -267,6 +268,14 @@ class SolrConnectionManager(object):
             schema = SolrSchema(manager=self)
             setattr(local_data, 'schema', schema)
         return schema
+
+    @property
+    def config(self):
+        config = getattr(local_data, 'config', None)
+        if not config:
+            config = SolrConfig(manager=self)
+            setattr(local_data, 'config', config)
+        return config
 
 
 class SolrResponse(object):

--- a/ftw/solr/tests/data/config.json
+++ b/ftw/solr/tests/data/config.json
@@ -1,0 +1,415 @@
+{
+  "responseHeader": {
+    "status": 0,
+    "QTime": 0
+  },
+  "config": {
+    "znodeVersion": 0,
+    "luceneMatchVersion": "8.11.1",
+    "updateHandler": {
+      "indexWriter": {
+        "closeWaitsForMerges": true
+      },
+      "commitWithin": {
+        "softCommit": true
+      },
+      "autoCommit": {
+        "maxDocs": -1,
+        "maxTime": 60000,
+        "openSearcher": false
+      },
+      "autoSoftCommit": {
+        "maxDocs": -1,
+        "maxTime": -1
+      }
+    },
+    "query": {
+      "useFilterForSortedQuery": false,
+      "queryResultWindowSize": 20,
+      "queryResultMaxDocsCached": 200,
+      "enableLazyFieldLoading": true,
+      "maxBooleanClauses": 1024,
+      "filterCache": {
+        "autowarmCount": "0",
+        "name": "filterCache",
+        "size": "512",
+        "class": "solr.FastLRUCache",
+        "initialSize": "512"
+      },
+      "queryResultCache": {
+        "autowarmCount": "0",
+        "name": "queryResultCache",
+        "size": "512",
+        "class": "solr.LRUCache",
+        "initialSize": "512"
+      },
+      "documentCache": {
+        "autowarmCount": "0",
+        "name": "documentCache",
+        "size": "512",
+        "class": "solr.LRUCache",
+        "initialSize": "512"
+      },
+      "fieldValueCache": {
+        "name": "fieldValueCache",
+        "size": "10000",
+        "showItems": "-1",
+        "initialSize": "10"
+      }
+    },
+    "requestHandler": {
+      "/select": {
+        "name": "/select",
+        "class": "solr.SearchHandler",
+        "defaults": {
+          "echoParams": "explicit",
+          "rows": 10
+        },
+        "last-components": [
+          "spellcheck"
+        ]
+      },
+      "/query": {
+        "name": "/query",
+        "class": "solr.SearchHandler",
+        "defaults": {
+          "echoParams": "explicit",
+          "wt": "json",
+          "indent": "true"
+        }
+      },
+      "/update": {
+        "name": "/update",
+        "class": "solr.UpdateRequestHandler"
+      },
+      "/update/extract": {
+        "startup": "lazy",
+        "name": "/update/extract",
+        "class": "solr.extraction.ExtractingRequestHandler",
+        "defaults": {
+          "lowernames": "false",
+          "xpath": "/xhtml:html/xhtml:body//text()",
+          "fmap.content": "SearchableText",
+          "uprefix": "ignored_",
+          "ignoreTikaException": true
+        }
+      },
+      "/dataimport": {
+        "name": "/dataimport",
+        "class": "solr.DataImportHandler",
+        "defaults": {
+          "config": "data-config.xml"
+        }
+      },
+      "/replication": {
+        "name": "/replication",
+        "class": "solr.ReplicationHandler",
+        "master": {
+          "replicateAfter": [
+            "commit",
+            "optimize"
+          ]
+        },
+        "slave": {
+          "enable": "false",
+          "masterUrl": "http://localhost:8983/solr/core/replication",
+          "pollInterval": "00:00:15"
+        }
+      },
+      "/spell": {
+        "startup": "lazy",
+        "name": "/spell",
+        "class": "solr.SearchHandler",
+        "defaults": {
+          "spellcheck.dictionary": "default",
+          "spellcheck": "on",
+          "spellcheck.extendedResults": "true",
+          "spellcheck.count": "10",
+          "spellcheck.alternativeTermCount": "5",
+          "spellcheck.maxResultsForSuggest": "5",
+          "spellcheck.collate": "true",
+          "spellcheck.collateExtendedResults": "true",
+          "spellcheck.maxCollationTries": "10",
+          "spellcheck.maxCollations": "5"
+        },
+        "last-components": [
+          "spellcheck"
+        ]
+      },
+      "/terms": {
+        "startup": "lazy",
+        "name": "/terms",
+        "class": "solr.SearchHandler",
+        "defaults": {
+          "terms": true,
+          "distrib": false
+        },
+        "components": [
+          "terms"
+        ]
+      },
+      "/update/json": {
+        "useParams": "_UPDATE_JSON",
+        "class": "solr.UpdateRequestHandler",
+        "invariants": {
+          "update.contentType": "application/json"
+        },
+        "name": "/update/json"
+      },
+      "/update/csv": {
+        "useParams": "_UPDATE_CSV",
+        "class": "solr.UpdateRequestHandler",
+        "invariants": {
+          "update.contentType": "application/csv"
+        },
+        "name": "/update/csv"
+      },
+      "/update/json/docs": {
+        "useParams": "_UPDATE_JSON_DOCS",
+        "class": "solr.UpdateRequestHandler",
+        "invariants": {
+          "update.contentType": "application/json",
+          "json.command": "false"
+        },
+        "name": "/update/json/docs"
+      },
+      "update": {
+        "class": "solr.UpdateRequestHandlerApi",
+        "useParams": "_UPDATE_JSON_DOCS",
+        "name": "update"
+      },
+      "/config": {
+        "useParams": "_CONFIG",
+        "class": "solr.SolrConfigHandler",
+        "name": "/config"
+      },
+      "/schema": {
+        "class": "solr.SchemaHandler",
+        "useParams": "_SCHEMA",
+        "name": "/schema"
+      },
+      "/get": {
+        "class": "solr.RealTimeGetHandler",
+        "useParams": "_GET",
+        "defaults": {
+          "omitHeader": true
+        },
+        "name": "/get"
+      },
+      "/admin/ping": {
+        "class": "solr.PingRequestHandler",
+        "useParams": "_ADMIN_PING",
+        "invariants": {
+          "echoParams": "all",
+          "q": "{!lucene}*:*"
+        },
+        "name": "/admin/ping"
+      },
+      "/admin/segments": {
+        "class": "solr.SegmentsInfoRequestHandler",
+        "useParams": "_ADMIN_SEGMENTS",
+        "name": "/admin/segments"
+      },
+      "/admin/luke": {
+        "class": "solr.LukeRequestHandler",
+        "useParams": "_ADMIN_LUKE",
+        "name": "/admin/luke"
+      },
+      "/admin/system": {
+        "class": "solr.SystemInfoHandler",
+        "useParams": "_ADMIN_SYSTEM",
+        "name": "/admin/system"
+      },
+      "/admin/mbeans": {
+        "class": "solr.SolrInfoMBeanHandler",
+        "useParams": "_ADMIN_MBEANS",
+        "name": "/admin/mbeans"
+      },
+      "/admin/plugins": {
+        "class": "solr.PluginInfoHandler",
+        "name": "/admin/plugins"
+      },
+      "/admin/threads": {
+        "class": "solr.ThreadDumpHandler",
+        "useParams": "_ADMIN_THREADS",
+        "name": "/admin/threads"
+      },
+      "/admin/properties": {
+        "class": "solr.PropertiesRequestHandler",
+        "useParams": "_ADMIN_PROPERTIES",
+        "name": "/admin/properties"
+      },
+      "/admin/logging": {
+        "class": "solr.LoggingHandler",
+        "useParams": "_ADMIN_LOGGING",
+        "name": "/admin/logging"
+      },
+      "/admin/file": {
+        "class": "solr.ShowFileRequestHandler",
+        "useParams": "_ADMIN_FILE",
+        "name": "/admin/file"
+      },
+      "/export": {
+        "class": "solr.ExportHandler",
+        "useParams": "_EXPORT",
+        "components": [
+          "query"
+        ],
+        "invariants": {
+          "rq": "{!xport}",
+          "distrib": false
+        },
+        "name": "/export"
+      },
+      "/graph": {
+        "class": "solr.GraphHandler",
+        "useParams": "_ADMIN_GRAPH",
+        "invariants": {
+          "wt": "graphml",
+          "distrib": false
+        },
+        "name": "/graph"
+      },
+      "/stream": {
+        "class": "solr.StreamHandler",
+        "useParams": "_STREAM",
+        "invariants": {
+          "distrib": false
+        },
+        "name": "/stream"
+      },
+      "/sql": {
+        "class": "solr.SQLHandler",
+        "useParams": "_SQL",
+        "invariants": {
+          "distrib": false
+        },
+        "name": "/sql"
+      },
+      "/analysis/document": {
+        "class": "solr.DocumentAnalysisRequestHandler",
+        "startup": "lazy",
+        "useParams": "_ANALYSIS_DOCUMENT",
+        "name": "/analysis/document"
+      },
+      "/analysis/field": {
+        "class": "solr.FieldAnalysisRequestHandler",
+        "startup": "lazy",
+        "useParams": "_ANALYSIS_FIELD",
+        "name": "/analysis/field"
+      },
+      "/debug/dump": {
+        "class": "solr.DumpRequestHandler",
+        "useParams": "_DEBUG_DUMP",
+        "defaults": {
+          "echoParams": "explicit",
+          "echoHandler": true
+        },
+        "name": "/debug/dump"
+      }
+    },
+    "queryResponseWriter": {
+      "json": {
+        "name": "json",
+        "class": "solr.JSONResponseWriter",
+        "content-type": "text/plain; charset=UTF-8"
+      }
+    },
+    "searchComponent": {
+      "spellcheck": {
+        "name": "spellcheck",
+        "class": "solr.SpellCheckComponent",
+        "queryAnalyzerFieldType": "text",
+        "spellchecker": {
+          "name": "default",
+          "field": "SearchableText",
+          "classname": "solr.DirectSolrSpellChecker",
+          "distanceMeasure": "internal",
+          "accuracy": 0.5,
+          "maxQueryFrequency": 0.01,
+          "maxEdits": 2,
+          "minPrefix": 1,
+          "maxInspections": 5,
+          "minQueryLength": 4
+        }
+      },
+      "terms": {
+        "name": "terms",
+        "class": "solr.TermsComponent"
+      }
+    },
+    "initParams": [
+      {
+        "path": "/update/**,/query,/select,/spell",
+        "name": "/update/**,/query,/select,/spell",
+        "defaults": {
+          "df": "SearchableText"
+        }
+      }
+    ],
+    "listener": [
+      {
+        "event": "newSearcher",
+        "class": "solr.QuerySenderListener",
+        "queries": []
+      },
+      {
+        "event": "firstSearcher",
+        "class": "solr.QuerySenderListener",
+        "queries": []
+      }
+    ],
+    "directoryFactory": {
+      "name": "DirectoryFactory",
+      "class": "solr.NRTCachingDirectoryFactory"
+    },
+    "codecFactory": {
+      "class": "solr.SchemaCodecFactory"
+    },
+    "updateRequestProcessorChain": [
+      {
+        "name": "sync.chain",
+        "": [
+          {
+            "class": "solr.processor.StatelessScriptUpdateProcessorFactory"
+          },
+          {
+            "class": "solr.LogUpdateProcessorFactory"
+          },
+          {
+            "class": "solr.RunUpdateProcessorFactory"
+          }
+        ]
+      }
+    ],
+    "updateHandlerupdateLog": {
+      "dir": "",
+      "numVersionBuckets": 65536
+    },
+    "requestDispatcher": {
+      "handleSelect": false,
+      "httpCaching": {
+        "never304": true,
+        "etagSeed": "Solr",
+        "lastModFrom": "opentime",
+        "cacheControl": null
+      },
+      "requestParsers": {
+        "multipartUploadLimitKB": 2147483647,
+        "formUploadLimitKB": 2147483647,
+        "addHttpRequestToContext": false
+      }
+    },
+    "indexConfig": {
+      "useCompoundFile": false,
+      "maxBufferedDocs": -1,
+      "ramBufferSizeMB": 100.0,
+      "ramPerThreadHardLimitMB": -1,
+      "maxCommitMergeWaitTime": -1,
+      "writeLockTimeout": -1,
+      "lockType": "native",
+      "infoStreamEnabled": false,
+      "metrics": {}
+    }
+  }
+}

--- a/ftw/solr/tests/data/config_langid.json
+++ b/ftw/solr/tests/data/config_langid.json
@@ -1,0 +1,442 @@
+{
+  "responseHeader": {
+    "status": 0,
+    "QTime": 0
+  },
+  "config": {
+    "znodeVersion": 0,
+    "luceneMatchVersion": "8.11.1",
+    "updateHandler": {
+      "indexWriter": {
+        "closeWaitsForMerges": true
+      },
+      "commitWithin": {
+        "softCommit": true
+      },
+      "autoCommit": {
+        "maxDocs": -1,
+        "maxTime": 60000,
+        "openSearcher": false
+      },
+      "autoSoftCommit": {
+        "maxDocs": -1,
+        "maxTime": -1
+      }
+    },
+    "query": {
+      "useFilterForSortedQuery": false,
+      "queryResultWindowSize": 20,
+      "queryResultMaxDocsCached": 200,
+      "enableLazyFieldLoading": true,
+      "maxBooleanClauses": 1024,
+      "filterCache": {
+        "autowarmCount": "0",
+        "name": "filterCache",
+        "size": "512",
+        "class": "solr.FastLRUCache",
+        "initialSize": "512"
+      },
+      "queryResultCache": {
+        "autowarmCount": "0",
+        "name": "queryResultCache",
+        "size": "512",
+        "class": "solr.LRUCache",
+        "initialSize": "512"
+      },
+      "documentCache": {
+        "autowarmCount": "0",
+        "name": "documentCache",
+        "size": "512",
+        "class": "solr.LRUCache",
+        "initialSize": "512"
+      },
+      "fieldValueCache": {
+        "name": "fieldValueCache",
+        "size": "10000",
+        "showItems": "-1",
+        "initialSize": "10"
+      }
+    },
+    "requestHandler": {
+      "/select": {
+        "name": "/select",
+        "class": "solr.SearchHandler",
+        "defaults": {
+          "echoParams": "explicit",
+          "rows": 10
+        },
+        "last-components": [
+          "spellcheck"
+        ]
+      },
+      "/query": {
+        "name": "/query",
+        "class": "solr.SearchHandler",
+        "defaults": {
+          "echoParams": "explicit",
+          "wt": "json",
+          "indent": "true"
+        }
+      },
+      "/update": {
+        "name": "/update",
+        "class": "solr.UpdateRequestHandler",
+        "invariants": {
+          "update.chain": "langid"
+        }
+      },
+      "/update/extract": {
+        "startup": "lazy",
+        "name": "/update/extract",
+        "class": "solr.extraction.ExtractingRequestHandler",
+        "defaults": {
+          "lowernames": "false",
+          "xpath": "/xhtml:html/xhtml:body//text()",
+          "fmap.content": "SearchableText",
+          "uprefix": "ignored_",
+          "ignoreTikaException": true
+        },
+        "invariants": {
+          "update.chain": "langid"
+        }
+      },
+      "/dataimport": {
+        "name": "/dataimport",
+        "class": "solr.DataImportHandler",
+        "defaults": {
+          "config": "data-config.xml"
+        }
+      },
+      "/replication": {
+        "name": "/replication",
+        "class": "solr.ReplicationHandler",
+        "master": {
+          "replicateAfter": [
+            "commit",
+            "optimize"
+          ]
+        },
+        "slave": {
+          "enable": "false",
+          "masterUrl": "http://localhost:8983/solr/core/replication",
+          "pollInterval": "00:00:15"
+        }
+      },
+      "/spell": {
+        "startup": "lazy",
+        "name": "/spell",
+        "class": "solr.SearchHandler",
+        "defaults": {
+          "spellcheck.dictionary": "default",
+          "spellcheck": "on",
+          "spellcheck.extendedResults": "true",
+          "spellcheck.count": "10",
+          "spellcheck.alternativeTermCount": "5",
+          "spellcheck.maxResultsForSuggest": "5",
+          "spellcheck.collate": "true",
+          "spellcheck.collateExtendedResults": "true",
+          "spellcheck.maxCollationTries": "10",
+          "spellcheck.maxCollations": "5"
+        },
+        "last-components": [
+          "spellcheck"
+        ]
+      },
+      "/terms": {
+        "startup": "lazy",
+        "name": "/terms",
+        "class": "solr.SearchHandler",
+        "defaults": {
+          "terms": true,
+          "distrib": false
+        },
+        "components": [
+          "terms"
+        ]
+      },
+      "/update/json": {
+        "useParams": "_UPDATE_JSON",
+        "class": "solr.UpdateRequestHandler",
+        "invariants": {
+          "update.contentType": "application/json"
+        },
+        "name": "/update/json"
+      },
+      "/update/csv": {
+        "useParams": "_UPDATE_CSV",
+        "class": "solr.UpdateRequestHandler",
+        "invariants": {
+          "update.contentType": "application/csv"
+        },
+        "name": "/update/csv"
+      },
+      "/update/json/docs": {
+        "useParams": "_UPDATE_JSON_DOCS",
+        "class": "solr.UpdateRequestHandler",
+        "invariants": {
+          "update.contentType": "application/json",
+          "json.command": "false"
+        },
+        "name": "/update/json/docs"
+      },
+      "update": {
+        "class": "solr.UpdateRequestHandlerApi",
+        "useParams": "_UPDATE_JSON_DOCS",
+        "name": "update"
+      },
+      "/config": {
+        "useParams": "_CONFIG",
+        "class": "solr.SolrConfigHandler",
+        "name": "/config"
+      },
+      "/schema": {
+        "class": "solr.SchemaHandler",
+        "useParams": "_SCHEMA",
+        "name": "/schema"
+      },
+      "/get": {
+        "class": "solr.RealTimeGetHandler",
+        "useParams": "_GET",
+        "defaults": {
+          "omitHeader": true
+        },
+        "name": "/get"
+      },
+      "/admin/ping": {
+        "class": "solr.PingRequestHandler",
+        "useParams": "_ADMIN_PING",
+        "invariants": {
+          "echoParams": "all",
+          "q": "{!lucene}*:*"
+        },
+        "name": "/admin/ping"
+      },
+      "/admin/segments": {
+        "class": "solr.SegmentsInfoRequestHandler",
+        "useParams": "_ADMIN_SEGMENTS",
+        "name": "/admin/segments"
+      },
+      "/admin/luke": {
+        "class": "solr.LukeRequestHandler",
+        "useParams": "_ADMIN_LUKE",
+        "name": "/admin/luke"
+      },
+      "/admin/system": {
+        "class": "solr.SystemInfoHandler",
+        "useParams": "_ADMIN_SYSTEM",
+        "name": "/admin/system"
+      },
+      "/admin/mbeans": {
+        "class": "solr.SolrInfoMBeanHandler",
+        "useParams": "_ADMIN_MBEANS",
+        "name": "/admin/mbeans"
+      },
+      "/admin/plugins": {
+        "class": "solr.PluginInfoHandler",
+        "name": "/admin/plugins"
+      },
+      "/admin/threads": {
+        "class": "solr.ThreadDumpHandler",
+        "useParams": "_ADMIN_THREADS",
+        "name": "/admin/threads"
+      },
+      "/admin/properties": {
+        "class": "solr.PropertiesRequestHandler",
+        "useParams": "_ADMIN_PROPERTIES",
+        "name": "/admin/properties"
+      },
+      "/admin/logging": {
+        "class": "solr.LoggingHandler",
+        "useParams": "_ADMIN_LOGGING",
+        "name": "/admin/logging"
+      },
+      "/admin/file": {
+        "class": "solr.ShowFileRequestHandler",
+        "useParams": "_ADMIN_FILE",
+        "name": "/admin/file"
+      },
+      "/export": {
+        "class": "solr.ExportHandler",
+        "useParams": "_EXPORT",
+        "components": [
+          "query"
+        ],
+        "invariants": {
+          "rq": "{!xport}",
+          "distrib": false
+        },
+        "name": "/export"
+      },
+      "/graph": {
+        "class": "solr.GraphHandler",
+        "useParams": "_ADMIN_GRAPH",
+        "invariants": {
+          "wt": "graphml",
+          "distrib": false
+        },
+        "name": "/graph"
+      },
+      "/stream": {
+        "class": "solr.StreamHandler",
+        "useParams": "_STREAM",
+        "invariants": {
+          "distrib": false
+        },
+        "name": "/stream"
+      },
+      "/sql": {
+        "class": "solr.SQLHandler",
+        "useParams": "_SQL",
+        "invariants": {
+          "distrib": false
+        },
+        "name": "/sql"
+      },
+      "/analysis/document": {
+        "class": "solr.DocumentAnalysisRequestHandler",
+        "startup": "lazy",
+        "useParams": "_ANALYSIS_DOCUMENT",
+        "name": "/analysis/document"
+      },
+      "/analysis/field": {
+        "class": "solr.FieldAnalysisRequestHandler",
+        "startup": "lazy",
+        "useParams": "_ANALYSIS_FIELD",
+        "name": "/analysis/field"
+      },
+      "/debug/dump": {
+        "class": "solr.DumpRequestHandler",
+        "useParams": "_DEBUG_DUMP",
+        "defaults": {
+          "echoParams": "explicit",
+          "echoHandler": true
+        },
+        "name": "/debug/dump"
+      }
+    },
+    "queryResponseWriter": {
+      "json": {
+        "name": "json",
+        "class": "solr.JSONResponseWriter",
+        "content-type": "text/plain; charset=UTF-8"
+      }
+    },
+    "searchComponent": {
+      "spellcheck": {
+        "name": "spellcheck",
+        "class": "solr.SpellCheckComponent",
+        "queryAnalyzerFieldType": "text",
+        "spellchecker": {
+          "name": "default",
+          "field": "SearchableText",
+          "classname": "solr.DirectSolrSpellChecker",
+          "distanceMeasure": "internal",
+          "accuracy": 0.5,
+          "maxQueryFrequency": 0.01,
+          "maxEdits": 2,
+          "minPrefix": 1,
+          "maxInspections": 5,
+          "minQueryLength": 4
+        }
+      },
+      "terms": {
+        "name": "terms",
+        "class": "solr.TermsComponent"
+      }
+    },
+    "initParams": [
+      {
+        "path": "/update/**,/query,/select,/spell",
+        "name": "/update/**,/query,/select,/spell",
+        "defaults": {
+          "df": "SearchableText"
+        }
+      }
+    ],
+    "listener": [
+      {
+        "event": "newSearcher",
+        "class": "solr.QuerySenderListener",
+        "queries": []
+      },
+      {
+        "event": "firstSearcher",
+        "class": "solr.QuerySenderListener",
+        "queries": []
+      }
+    ],
+    "directoryFactory": {
+      "name": "DirectoryFactory",
+      "class": "solr.NRTCachingDirectoryFactory"
+    },
+    "codecFactory": {
+      "class": "solr.SchemaCodecFactory"
+    },
+    "updateRequestProcessorChain": [
+      {
+        "name": "langid",
+        "": [
+          {
+            "class": "org.apache.solr.update.processor.LangDetectLanguageIdentifierUpdateProcessorFactory",
+            "langid.fl": "Description,SearchableText,Title",
+            "langid.langField": "_language_",
+            "langid.whitelist": "de,en,fr",
+            "langid.fallback": "general",
+            "langid.map": true,
+            "langid.map.individual": true,
+            "langid.map.keepOrig": true
+          },
+          {
+            "class": "solr.LogUpdateProcessorFactory"
+          },
+          {
+            "class": "solr.RunUpdateProcessorFactory"
+          }
+        ]
+      },
+      {
+        "name": "sync.chain",
+        "": [
+          {
+            "class": "solr.processor.StatelessScriptUpdateProcessorFactory"
+          },
+          {
+            "class": "solr.LogUpdateProcessorFactory"
+          },
+          {
+            "class": "solr.RunUpdateProcessorFactory"
+          }
+        ]
+      }
+    ],
+    "updateHandlerupdateLog": {
+      "dir": "",
+      "numVersionBuckets": 65536
+    },
+    "requestDispatcher": {
+      "handleSelect": false,
+      "httpCaching": {
+        "never304": true,
+        "etagSeed": "Solr",
+        "lastModFrom": "opentime",
+        "cacheControl": null
+      },
+      "requestParsers": {
+        "multipartUploadLimitKB": 2147483647,
+        "formUploadLimitKB": 2147483647,
+        "addHttpRequestToContext": false
+      }
+    },
+    "indexConfig": {
+      "useCompoundFile": false,
+      "maxBufferedDocs": -1,
+      "ramBufferSizeMB": 100.0,
+      "ramPerThreadHardLimitMB": -1,
+      "maxCommitMergeWaitTime": -1,
+      "writeLockTimeout": -1,
+      "lockType": "native",
+      "infoStreamEnabled": false,
+      "metrics": {}
+    }
+  }
+}

--- a/ftw/solr/tests/data/schema_langid.json
+++ b/ftw/solr/tests/data/schema_langid.json
@@ -1,0 +1,128 @@
+{
+    "responseHeader": {
+        "QTime": 1,
+        "status": 0
+    },
+    "schema": {
+        "copyFields": [],
+        "dynamicFields": [],
+        "fieldTypes": [
+            {
+                "class": "solr.BoolField",
+                "name": "boolean",
+                "sortMissingLast": true
+            },
+            {
+                "class": "solr.LongPointField",
+                "docValues": true,
+                "name": "plong"
+            },
+            {
+                "class": "solr.IntPointField",
+                "docValues": true,
+                "name": "pint"
+            },
+            {
+                "class": "solr.StrField",
+                "docValues": true,
+                "name": "string",
+                "sortMissingLast": true
+            },
+            {
+                "class": "solr.DatePointField",
+                "docValues": true,
+                "name": "pdate",
+                "sortMissingLast": true
+            },
+            {
+                "class": "solr.TextField",
+                "name": "text"
+            }
+        ],
+        "fields": [
+            {
+                "docValues": false,
+                "indexed": true,
+                "name": "_root_",
+                "stored": false,
+                "type": "string"
+            },
+            {
+                "indexed": false,
+                "name": "_version_",
+                "stored": false,
+                "type": "plong"
+            },
+            {
+                "indexed": true,
+                "name": "UID",
+                "required": true,
+                "type": "string"
+            },
+            {
+                "indexed": true,
+                "name": "path",
+                "stored": false,
+                "type": "string"
+            },
+            {
+                "indexed": true,
+                "name": "path_depth",
+                "stored": false,
+                "type": "pint"
+            },
+            {
+                "indexed": true,
+                "name": "Title",
+                "stored": false,
+                "type": "string"
+            },
+            {
+                "indexed": true,
+                "name": "Title_de",
+                "stored": true,
+                "type": "string"
+            },
+            {
+                "indexed": true,
+                "name": "Title_en",
+                "stored": true,
+                "type": "string"
+            },
+            {
+                "indexed": true,
+                "name": "Title_fr",
+                "stored": true,
+                "type": "string"
+            },
+            {
+                "indexed": true,
+                "name": "Title_general",
+                "stored": true,
+                "type": "string"
+            },
+            {
+                "indexed": true,
+                "multiValued": true,
+                "name": "allowedRolesAndUsers",
+                "type": "string",
+                "stored": "false"
+            },
+            {
+                "indexed": true,
+                "name": "SearchableText",
+                "stored": true,
+                "type": "text"
+            },
+            {
+                "indexed": true,
+                "name": "modified",
+                "stored": false,
+                "type": "pdate"
+            }
+        ],
+        "name": "default-config",
+        "uniqueKey": "UID",
+        "version": 1.6
+    }
+}

--- a/ftw/solr/tests/test_config.py
+++ b/ftw/solr/tests/test_config.py
@@ -1,0 +1,57 @@
+from ftw.solr.config import SolrConfig
+from ftw.solr.connection import SolrResponse
+from ftw.solr.tests.utils import get_data
+from mock import MagicMock
+from mock import PropertyMock
+import unittest
+
+
+class TestConfig(unittest.TestCase):
+
+    def setUp(self):
+        conn = MagicMock(name='SolrConnection')
+        conn.get = MagicMock(name='get', return_value=SolrResponse(
+            body=get_data('config_langid.json'), status=200))
+        manager = MagicMock(name='SolrConnectionManager')
+        type(manager).connection = PropertyMock(return_value=conn)
+        self.config = SolrConfig(manager)
+
+    def test_config_retrieval(self):
+        config = self.config
+        self.assertEqual(config.config[u'luceneMatchVersion'], u'8.11.1')
+
+    def test_langid_settings(self):
+        self.assertEqual(
+            self.config.langid_fields,
+            [u'Description', u'SearchableText', u'Title'],
+        )
+        self.assertEqual(
+            self.config.langid_langs, [u'de', u'en', u'fr', u'general'])
+        self.assertEqual(
+            self.config.langid_langfields,
+            [
+                u'Description_de',
+                u'Description_en',
+                u'Description_fr',
+                u'Description_general',
+                u'SearchableText_de',
+                u'SearchableText_en',
+                u'SearchableText_fr',
+                u'SearchableText_general',
+                u'Title_de',
+                u'Title_en',
+                u'Title_fr',
+                u'Title_general',
+            ],
+        )
+
+    def test_langid_settings_without_langid_processor(self):
+        conn = MagicMock(name='SolrConnection')
+        conn.get = MagicMock(name='get', return_value=SolrResponse(
+            body=get_data('config.json'), status=200))
+        manager = MagicMock(name='SolrConnectionManager')
+        type(manager).connection = PropertyMock(return_value=conn)
+        config = SolrConfig(manager)
+        self.assertEqual(config.langid_fields, [])
+        self.assertEqual(config.langid_langs, [])
+        self.assertEqual(config.langid_langfields, [])


### PR DESCRIPTION
Language specific fields require some special handling.
If e.g. the field `Title` is indexed language specifically, you have to define a field for each supported language: `Title_de`, `Title_en`, `Title_fr`, etc. When indexing `Title`, Solr automatically renames the field to the detected language e.g. `Title_de` and indexes it. When indexing the field again, another language may be detected, e.g. `Title_en`.  Because we use atomic updates, the previous `Title_de` is kept in the index. Therefore we first delete all language variants of the indexed field to ensure we only have the current value in the index.

In order to not duplicate configuration, we determine language specific fields from the Solr configuration.

For [CA-4241](https://4teamwork.atlassian.net/browse/CA-4241)