### PR TITLE
Add option to execute update commands in post commit hook.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 -------------------
 
 - Add option to also check allowedRolesAndUsers when determining items not up to date in Solr. [njohner]
+- Add option to execute update commands in post commit hook. [njohner]
 
 
 2.11.0 (2022-07-04)

--- a/ftw/solr/browser/maintenance.py
+++ b/ftw/solr/browser/maintenance.py
@@ -146,7 +146,7 @@ class SolrMaintenanceView(BrowserView):
 
         def commit():
             conn = self.manager.connection
-            conn.commit(soft_commit=False, extract_after_commit=False)
+            conn.commit(soft_commit=False, after_commit=False)
             zodb_conn.cacheGC()
             self.log(
                 'Intermediate commit (%d items processed, last batch in %s)',
@@ -207,7 +207,7 @@ class SolrMaintenanceView(BrowserView):
 
         def commit():
             conn = self.manager.connection
-            conn.commit(soft_commit=False, extract_after_commit=False)
+            conn.commit(soft_commit=False, after_commit=False)
             zodb_conn.cacheGC()
             self.log(
                 'Intermediate commit (%d items processed, last batch in %s)',
@@ -334,7 +334,7 @@ class SolrMaintenanceView(BrowserView):
 
         def commit():
             conn = self.manager.connection
-            conn.commit(soft_commit=False, extract_after_commit=False)
+            conn.commit(soft_commit=False, after_commit=False)
             zodb_conn.cacheGC()
             self.log(
                 'Intermediate commit (%d items processed, last batch in %s)',

--- a/ftw/solr/interfaces.py
+++ b/ftw/solr/interfaces.py
@@ -87,3 +87,11 @@ class ISolrSettings(Interface):
                     u'query.',
         default=u'Title:({phrase})^10 OR SearchableText:({phrase})',
     )
+
+    enable_updates_in_post_commit_hook = Bool(
+        title=u'Enable performing update operations in a post commit hook.',
+        description=u'Check this to allow performing update operations in a '
+                    u'post commit hook. This allows to optimize the time the '
+                    u'zodb is locked.',
+        default=False,
+    )

--- a/ftw/solr/interfaces.py
+++ b/ftw/solr/interfaces.py
@@ -93,5 +93,5 @@ class ISolrSettings(Interface):
         description=u'Check this to allow performing update operations in a '
                     u'post commit hook. This allows to optimize the time the '
                     u'zodb is locked.',
-        default=False,
+        default=True,
     )

--- a/ftw/solr/tests/test_connection.py
+++ b/ftw/solr/tests/test_connection.py
@@ -86,7 +86,7 @@ class TestConnection(unittest.TestCase):
         conn = SolrConnection(base='/solr/mycore')
         conn.flush = MagicMock(name='flush')
         conn.commit()
-        conn.flush.assert_called_once_with(extract_after_commit=True)
+        conn.flush.assert_called_once_with(after_commit=True)
         self.assertEqual(
             conn.update_commands,
             ['"commit": {"softCommit": true, "waitSearcher": true}'])
@@ -256,7 +256,7 @@ class TestConnection(unittest.TestCase):
         conn.post.return_value.body.get.return_value = 'The searchable text'
         conn.extract(MockBlob(), 'SearchableText', {'id': '1'},
                      'application/octet-stream')
-        conn.flush(extract_after_commit=False)
+        conn.flush(after_commit=False)
 
         args, kwargs = conn.post.call_args_list[0]
         self.assertEqual(

--- a/ftw/solr/upgrades/20200401111512_update_modified_index/upgrade.py
+++ b/ftw/solr/upgrades/20200401111512_update_modified_index/upgrade.py
@@ -124,7 +124,7 @@ class UpdateModifiedIndex(UpgradeStep):
 
         def commit():
             conn = self.manager.connection
-            conn.commit(soft_commit=False, extract_after_commit=False)
+            conn.commit(soft_commit=False, after_commit=False)
             self.log(
                 'Intermediate commit (%d items processed, last batch in %s)',
                 processed, next(lap))

--- a/ftw/solr/upgrades/20220718103046_add_enable_updates_in_post_commit_hook_setting/registry.xml
+++ b/ftw/solr/upgrades/20220718103046_add_enable_updates_in_post_commit_hook_setting/registry.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<registry>
+  <records interface="ftw.solr.interfaces.ISolrSettings" />
+</registry>

--- a/ftw/solr/upgrades/20220718103046_add_enable_updates_in_post_commit_hook_setting/upgrade.py
+++ b/ftw/solr/upgrades/20220718103046_add_enable_updates_in_post_commit_hook_setting/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddEnableUpdatesInPostCommitHookSetting(UpgradeStep):
+    """Add registry setting for enabling/disabling updates in post commit hook.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
The main advantage to execute the update commands in a post commit hook is to shorten the time the ZODB is locked. On disadvantage is that [the transaction does not get roll-backed when the after commit hooks fail](https://github.com/zopefoundation/transaction/blob/1.1.1/transaction/_transaction.py#L412-L421). This is of no concern here, as we anyway do not make the transaction fail when the [updates in solr go wrong](https://github.com/4teamwork/ftw.solr/blob/master/ftw/solr/connection.py#L166-L171). So there is no real drawback of executing all the update commands in an after transaction hook.

For https://4teamwork.atlassian.net/browse/CA-4291