### PR TITLE
Add option to check allowedRolesAndUsers in solr diff and sync.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2.11.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Add option to also check allowedRolesAndUsers when determining items not up to date in Solr. [njohner]
 
 
 2.11.0 (2022-07-04)

--- a/ftw/solr/commands.py
+++ b/ftw/solr/commands.py
@@ -58,6 +58,12 @@ def solr(app, args):
     parser.add_argument('--max-diff', dest='max_diff', default=5, type=int,
                         help="Maximum items to log in diff. Use negative "
                              "number for infinite.")
+    parser.add_argument('--include-allowed-roles-and-users',
+                        dest='include_allowed_roles_and_users',
+                        default=False,
+                        type=bool,
+                        help="Include allowedRolesAndUsers index when checking"
+                             "whether a document is up to date in solr.")
     options = parser.parse_args(args[2:])
     app = makerequest(app)
     site = setup_site(app, options)
@@ -77,7 +83,8 @@ def solr(app, args):
     elif options.command == 'sync':
         solr_maintenance.sync(
             commit_interval=options.commit_interval, idxs=options.indexes,
-            max_diff=max_diff)
+            max_diff=max_diff,
+            include_allowed_roles_and_users=options.include_allowed_roles_and_users)
     elif options.command == 'optimize':
         solr_maintenance.optimize()
         print("Solr index optimized.")
@@ -85,6 +92,8 @@ def solr(app, args):
         solr_maintenance.clear()
         print("Solr index cleared.")
     elif options.command == 'diff':
-        solr_maintenance.diff(max_diff=max_diff)
+        solr_maintenance.diff(
+            max_diff=max_diff,
+            include_allowed_roles_and_users=options.include_allowed_roles_and_users)
     else:
         sys.exit("Unknown command '%s'." % options.command)


### PR DESCRIPTION
The `allowedRolesAndUsers` index is crucial for the security and it is therefore useful to be able to make sure that this index is up to date. Testing the maintenance view is not really possible with our current testing infrastructure. 

For [CA-4291](https://4teamwork.atlassian.net/browse/CA-4291)