### PR TITLE
Make updates_in_post_commit_enabled() helper more robust:

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2.12.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Make updates_in_post_commit_enabled() helper more robust. [lgraf]
 
 
 2.12.0 (2022-07-19)

--- a/ftw/solr/connection.py
+++ b/ftw/solr/connection.py
@@ -165,6 +165,9 @@ class SolrConnection(object):
 
     def updates_in_post_commit_enabled(self):
         registry = queryUtility(IRegistry)
+        if registry is None:
+            # Plone site might not exist yet
+            return True
         settings = registry.forInterface(ISolrSettings)
         return settings.enable_updates_in_post_commit_hook
 


### PR DESCRIPTION
In situations where a Plone site doesn't exist yet (e.g. when attempting to purge Solr during Plone site setup), there won't be a Plone registry, and `queryUtility(IRegistry)` will return `None`, and the `updates_in_post_commit_enabled()` helper will fail.

This change fixes this by returning `True` (the settings interface's default) in this case.

(Fixes an issue where a GEVER can't be set up locally with the `[ ] Purge Solr` flag any more)