### PR TITLE
Fix solr sync maintenance command not committing all batches.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 2.13.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix solr sync maintenance command not committing all batches.
+  [lgraf]
 
 
 2.13.0 (2023-04-11)

--- a/ftw/solr/browser/maintenance.py
+++ b/ftw/solr/browser/maintenance.py
@@ -28,7 +28,7 @@ try:
     from time import clock
 except ImportError:
     from time import process_time as clock
-    
+
 
 import logging
 import transaction

--- a/ftw/solr/browser/maintenance.py
+++ b/ftw/solr/browser/maintenance.py
@@ -135,7 +135,7 @@ class SolrMaintenanceView(BrowserView):
             return 'Solr indexing is disabled.'
         conn = self.manager.connection
         conn.delete_by_query('*:*')
-        conn.commit(soft_commit=False)
+        conn.commit(soft_commit=False, after_commit=False)
         return 'Solr index cleared.'
 
     def reindex(self, commit_interval=100, idxs=None, doom=True):
@@ -366,7 +366,7 @@ class SolrMaintenanceView(BrowserView):
         conn = self.manager.connection
         for uid in not_in_catalog:
             conn.delete(uid)
-        conn.commit(soft_commit=False)
+        conn.commit(soft_commit=False, after_commit=False)
 
         self.log('Solr index synced.')
         self.log(


### PR DESCRIPTION
Fix solr sync maintenance command not committing all batches.

Because the maintenance view doesn't commit the ZODB transaction, Solr commits must not be deferred into a ZODB transaction post commit hook in this view, otherwise they won't get executed.

This lead to the last (or only) batch of items not getting committed (discovered during GDGS recovery).

This was partially addressed in #191, but some conn.commit()'s were missed (or maybe introduced later)