### PR TITLE
Log warning when a search is performed without specifying fl.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 2.13.1 (unreleased)
 -------------------
 
+- Log warning when a search is performed without specifying fl.
+  [njohner]
+
 - Fix solr sync maintenance command not committing all batches.
   [lgraf]
 

--- a/ftw/solr/search.py
+++ b/ftw/solr/search.py
@@ -2,9 +2,13 @@ from AccessControl.SecurityManagement import getSecurityManager
 from ftw.solr.interfaces import ISolrConnectionManager
 from ftw.solr.interfaces import ISolrSearch
 from ftw.solr.query import escape
+from logging import getLogger
 from Products.CMFPlone.utils import base_hasattr
 from zope.component import queryUtility
 from zope.interface import implementer
+
+
+logger = getLogger('ftw.solr.search')
 
 
 @implementer(ISolrSearch)
@@ -22,6 +26,9 @@ class SolrSearch(object):
 
     def _search(self, request_handler=u'/select', query=u'*:*', filters=None,
                 start=0, rows=1000, sort=None, unrestricted=False, **params):
+        if rows and not params.get("fl"):
+            logger.warning("Not specifying the fl parameter can dramatically "
+                           "impact performance")
         conn = self.manager.connection
         params = {u'params': params}
         params[u'query'] = query


### PR DESCRIPTION
Not specifying fl will return all fields, includung searchableText which will typically dramatically impact performance.

Tests should get fixed with https://github.com/4teamwork/ftw-buildouts/pull/215

For https://4teamwork.atlassian.net/browse/CA-5921