### PR TITLE
Fix argument parsing of zopectl command

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 2.13.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix argument parsing of zopectl command if run with Zope2.Startup.zopectl.
+  [buchi]
 
 
 2.13.1 (2023-06-20)

--- a/ftw/solr/commands.py
+++ b/ftw/solr/commands.py
@@ -65,7 +65,12 @@ def solr(app, args):
                         type=bool,
                         help="Include allowedRolesAndUsers index when checking"
                              "whether a document is up to date in solr.")
-    options = parser.parse_args(args[2:])
+
+    # If run with plone.recipe.zope2instance we need to strip the first 2 args
+    if sys.argv[0] != 'solr':
+        args = args[2:]
+    options = parser.parse_args(args)
+
     app = makerequest(app)
     site = setup_site(app, options)
 

--- a/test-plone-5.2.x-py37.cfg
+++ b/test-plone-5.2.x-py37.cfg
@@ -1,9 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-5.2.x-py37.cfg
-
-package-name = ftw.solr
-
-[versions]
-importlib-metadata =0.23
-collective.xmltestreport = 2.0.2

--- a/test-plone-5.2.x-py38.cfg
+++ b/test-plone-5.2.x-py38.cfg
@@ -7,3 +7,5 @@ package-name = ftw.solr
 [versions]
 importlib-metadata =0.23
 collective.xmltestreport = 2.0.2
+setuptools = 44.1.1
+zc.buildout = 2.13.8


### PR DESCRIPTION
Stripping arguments is only needed if ftw.solr is installed with buildout using the `plone.recipe.zope2instance` recipe.
It breaks installations that rely on `Zope2.Startup.zopectl`.