### PR TITLE
Fix getting global request in zopectl command

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 2.13.4 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix getting global request in zopectl command.
+  [buchi]
 
 
 2.13.3 (2024-10-14)

--- a/ftw/solr/commands.py
+++ b/ftw/solr/commands.py
@@ -2,6 +2,7 @@ from AccessControl.SecurityManagement import newSecurityManager
 from Products.CMFPlone.interfaces import IPloneSiteRoot
 from zope.component import queryMultiAdapter
 from zope.component.hooks import setSite
+from zope.globalrequest import setRequest
 
 import argparse
 import sys
@@ -77,6 +78,7 @@ def solr(app, args):
     # DemoStorage database instead of the one from the config file.
     from Testing.makerequest import makerequest
     app = makerequest(app)
+    setRequest(app.REQUEST)
     site = setup_site(app, options)
 
     max_diff = options.max_diff


### PR DESCRIPTION
Custom indexers may use `getRequest` from `zope.globalrequest` to get the request object. This needs to be setup in the zopectl command.